### PR TITLE
refactor: rename project to `tsl`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 *.map
 packages/*/index.js
 packages/*/lib/**/*.js
-.tsslint/
+.tsl/

--- a/README.md
+++ b/README.md
@@ -1,28 +1,30 @@
-# TSSLint
+# TypeScript Linter (TSL)
 
 > A lightweight inspection tool that seamlessly integrates with TypeScript Language Server
 
-TSSLint is not your typical linter. Its main purpose is to expose the TypeScript Language Server diagnostic interface, allowing you to add your own diagnostic rules without additional overhead to creating a TypeChecker.
+TSL is not your typical linter. Its main purpose is to expose the TypeScript Language Server diagnostic interface, allowing you to add your own diagnostic rules without additional overhead to creating a TypeChecker.
 
 Discord Server: https://discord.gg/NpdmPEUNjE
+
+Special thanks to @basarat for transferring the `tsl` package name.
 
 ## Packages
 
 This repository is a monorepo that we manage using [Lerna-Lite](https://github.com/lerna-lite/lerna-lite). That means that we actually publish several packages to npm from the same codebase, including:
 
-- [`@tsslint/cli`](packages/cli): This package provides the command line interface for TSSLint.
-- [`@tsslint/config`](packages/config): This package allows you to define and build configuration files for TSSLint.
-- [`@tsslint/core`](packages/core): This is the core package for TSSLint, which provides the main functionality of the tool.
-- [`@tsslint/typescript-plugin`](packages/typescript-plugin): This package integrates TSSLint with the TypeScript language server.
-- [`@tsslint/vscode`](packages/vscode): This package is a Visual Studio Code extension that integrates TSSLint into the editor.
+- [`cli`](packages/cli): This package provides the command line interface for TSL.
+- [`config`](packages/config): This package allows you to define and build configuration files for TSL.
+- [`core`](packages/core): This is the core package for TSL, which provides the main functionality of the tool.
+- [`typescript-plugin`](packages/typescript-plugin): This package integrates TSL with the TypeScript language server.
+- [`vscode`](packages/vscode): This package is a Visual Studio Code extension that integrates TSL into the editor.
 
-## Why TSSLint?
+## Why TSL?
 
 The performance of TypeScript in code editors has always been a crucial concern. Most TypeScript tools integrate TypeScript libraries to enable type checking and query code types through the LanguageService or TypeChecker API.
 
 However, for complex types or large codebases, the tsserver process can consume significant memory and CPU resources. When linter tools integrate with TypeScript and create their own LanguageService instances, memory and CPU usage can continue to increase. In some cases, this has caused projects to experience long save times when codeActionOnSave is enabled in VSCode.
 
-TSSLint aims to seamlessly integrate with tsserver to minimize unnecessary overhead and provide linting capabilities on top of it.
+TSL aims to seamlessly integrate with tsserver to minimize unnecessary overhead and provide linting capabilities on top of it.
 
 ## Features
 
@@ -32,13 +34,20 @@ TSSLint aims to seamlessly integrate with tsserver to minimize unnecessary overh
 
 ## Usage
 
-To enable TSSLint in your IDE, follow these steps:
+To enable TSL in VSCode, follow these steps:
 
-1. Install the [TSSLint VSCode Extension](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-tsslint)
-2. Add the `@tsslint/config` dependency to your project.
-3. Create the `tsslint.config.ts` config file:
+1. Install the [TSL VSCode Extension](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-tsslint)
+2. Add the `tsl` dependency to your project.
+	```json
+	{
+		"devDependencies": {
+			"tsl": "latest"
+		}
+	}
+	```
+3. Create the `tsl.config.ts` config file:
 	```js
-	import { defineConfig } from '@tsslint/config';
+	import { defineConfig } from 'tsl';
 
 	export default defineConfig({
 		rules: {
@@ -56,7 +65,7 @@ As an example, let's create a `no-console` rule under `[project root]/rules/`.
 Here's the code for `[project root]/rules/noConsoleRule.ts`:
 
 ```js
-import type { Rule } from '@tsslint/config';
+import type { Rule } from 'tsl';
 
 const rule: Rule = ({ typescript: ts, sourceFile, reportWarning }) => {
 	ts.forEachChild(sourceFile, function walk(node) {
@@ -90,10 +99,10 @@ const rule: Rule = ({ typescript: ts, sourceFile, reportWarning }) => {
 export default rule;
 ```
 
-Then add it to the `tsslint.config.ts` config file.
+Then add it to the `tsl.config.ts` config file.
 
 ```diff
-import { defineConfig } from '@tsslint/config';
+import { defineConfig } from 'tsl';
 + import noConsoleRule from './rules/noConsoleRule.ts';
 
 export default defineConfig({
@@ -109,10 +118,10 @@ After saving the config file, you will notice that `console.log` is now reportin
 
 While you cannot directly configure the severity of a rule, you can modify the reported errors through the `resolveDiagnostics()` API in the config file. This allows you to customize the severity of specific rules and even add additional errors.
 
-Here's an example of changing the severity of the `no-console` rule from Warning to Error in the `tsslint.config.ts` file:
+Here's an example of changing the severity of the `no-console` rule from Warning to Error in the `tsl.config.ts` file:
 
 ```js
-import { defineConfig } from 'tsslint';
+import { defineConfig } from 'tsl';
 import noConsoleRule from './rules/noConsoleRule.ts';
 
 export default defineConfig({

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -80,9 +80,9 @@ import glob = require('glob');
 
 		log.step(`Project: ${path.relative(process.cwd(), tsconfig)} (${parseCommonLine(tsconfig).fileNames.length} input files)`);
 
-		const configFile = ts.findConfigFile(path.dirname(tsconfig), ts.sys.fileExists, 'tsslint.config.ts');
+		const configFile = ts.findConfigFile(path.dirname(tsconfig), ts.sys.fileExists, 'tsl.config.ts');
 		if (!configFile) {
-			log.error('No tsslint.config.ts file found!');
+			log.error('No tsl.config.ts file found!');
 			return;
 		}
 		log.message(`Config: ${path.relative(process.cwd(), configFile)}`);
@@ -178,7 +178,7 @@ import glob = require('glob');
 				shortTsconfig = `./${shortTsconfig}`;
 			}
 			tsconfig = await text({
-				message: 'Select the tsconfig project. (You can use --project to skip this prompt.)',
+				message: 'Select the tsconfig project. (You can use --project or --projects to skip this prompt.)',
 				placeholder: shortTsconfig ? `${shortTsconfig} (${parseCommonLine(tsconfig!).fileNames.length} input files)` : 'No tsconfig.json found, please enter the path to your tsconfig.json file.',
 				defaultValue: shortTsconfig,
 				validate(value) {

--- a/packages/config/lib/watch.ts
+++ b/packages/config/lib/watch.ts
@@ -12,7 +12,7 @@ export async function watchConfigFile(
 		__dirname,
 		'..',
 		'..',
-		'.tsslint',
+		'.tsl',
 	);
 	const outFileName = createHash(path.relative(outDir, configFilePath)) + '.cjs';
 	const outFile = path.join(outDir, outFileName);
@@ -36,7 +36,7 @@ export async function watchConfigFile(
 		format: 'cjs',
 		platform: 'node',
 		plugins: [{
-			name: 'tsslint',
+			name: 'tsl',
 			setup(build) {
 				build.onResolve({ filter: /.*/ }, args => {
 					if (!args.path.endsWith('.ts')) {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -87,7 +87,7 @@ export function createLinter(ctx: ProjectContext, config: Config, withStack: boo
 					file: sourceFile!,
 					start,
 					length: end - start,
-					source: 'tsslint',
+					source: 'tsl',
 					relatedInformation: [],
 				};
 				const stacks = trace ? ErrorStackParser.parse(new Error()) : [];
@@ -175,11 +175,11 @@ export function createLinter(ctx: ProjectContext, config: Config, withStack: boo
 						(end >= fix.start && end <= fix.end)
 					) {
 						result.push({
-							fixName: `tsslint: ${fix.title}`,
+							fixName: `tsl: ${fix.title}`,
 							description: fix.title,
 							changes: fix.getEdits(),
-							fixId: 'tsslint',
-							fixAllDescription: 'Fix all TSSLint errors'
+							fixId: 'tsl',
+							fixAllDescription: 'Fix all TSL errors'
 						});
 					}
 				}

--- a/packages/tsl/LICENSE
+++ b/packages/tsl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tsl/bin/tsl.js
+++ b/packages/tsl/bin/tsl.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('@tsslint/cli');

--- a/packages/tsl/index.ts
+++ b/packages/tsl/index.ts
@@ -1,0 +1,2 @@
+export * from '@tsslint/config';
+export * from '@tsslint/core';

--- a/packages/tsl/package.json
+++ b/packages/tsl/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "tsl",
+	"version": "0.0.8",
+	"license": "MIT",
+	"bin": {
+		"tsl": "./bin/tsl.js"
+	},
+	"files": [
+		"**/*.js",
+		"**/*.d.ts"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/johnsoncodehk/tsslint.git",
+		"directory": "packages/tsl"
+	},
+	"dependencies": {
+		"@tsslint/cli": "0.0.8",
+		"@tsslint/config": "0.0.8",
+		"@tsslint/core": "0.0.8"
+	}
+}

--- a/packages/tsl/tsconfig.json
+++ b/packages/tsl/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [ "*", "lib/**/*" ],
+	"references": [
+		{ "path": "../cli/tsconfig.json" },
+		{ "path": "../config/tsconfig.json" },
+		{ "path": "../core/tsconfig.json" },
+	],
+}

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -63,7 +63,7 @@ function decorateLanguageService(
 		if (config?.debug) {
 			result.push({
 				category: ts.DiagnosticCategory.Warning,
-				source: 'tsslint',
+				source: 'tsl',
 				code: 'debug-info' as any,
 				messageText: JSON.stringify({
 					rules: Object.keys(config?.rules ?? {}),
@@ -85,7 +85,7 @@ function decorateLanguageService(
 		];
 	};
 	info.languageService.getCombinedCodeFix = (scope, fixId, formatOptions, preferences) => {
-		if (fixId === 'tsslint' && linter) {
+		if (fixId === 'tsl' && linter) {
 			const fixes = linter.getCodeFixes(scope.fileName, 0, Number.MAX_VALUE);
 			const changes = combineCodeFixes(scope.fileName, fixes);
 			return {
@@ -120,7 +120,7 @@ function decorateLanguageService(
 			}
 		}
 		else {
-			newConfigFile = ts.findConfigFile(path.dirname(tsconfig), ts.sys.fileExists, 'tsslint.config.ts');
+			newConfigFile = ts.findConfigFile(path.dirname(tsconfig), ts.sys.fileExists, 'tsl.config.ts');
 		}
 
 		if (newConfigFile !== configFile) {
@@ -148,7 +148,7 @@ function decorateLanguageService(
 			let configImportPath: string | undefined;
 
 			try {
-				configImportPath = require.resolve('@tsslint/config', { paths: [configFile] });
+				configImportPath = require.resolve('tsl', { paths: [configFile] });
 			} catch (err) {
 				configFileDiagnostics = [{
 					category: ts.DiagnosticCategory.Error,
@@ -180,7 +180,7 @@ function decorateLanguageService(
 					].map(([error, category]) => {
 						const diag: ts.Diagnostic = {
 							category,
-							source: 'tsslint',
+							source: 'tsl',
 							code: 0,
 							messageText: 'Failed to build config',
 							file: jsonConfigFile,

--- a/packages/vscode/extension.js
+++ b/packages/vscode/extension.js
@@ -12,11 +12,11 @@ try {
 			let text = readFileSync(...args);
 
 			// patch getFixableDiagnosticsForContext
-			text = text.replace('t.has(e.code+"")', s => `(${s}||e.source==="tsslint")`);
+			text = text.replace('t.has(e.code+"")', s => `(${s}||e.source==="tsl")`);
 
 			// patch buildIndividualFixes
-			text = text.replace('!r.has(s.code)', s => `${s}&&s.source!=="tsslint"`);
-			text = text.replace('e.fixName===o', s => `${s}||s.source==="tsslint"`);
+			text = text.replace('!r.has(s.code)', s => `${s}&&s.source!=="tsl"`);
+			text = text.replace('e.fixName===o', s => `${s}||s.source==="tsl"`);
 
 			return text;
 		}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -11,8 +11,8 @@
 		"url": "https://github.com/sponsors/johnsoncodehk"
 	},
 	"main": "./extension.js",
-	"displayName": "TSSLint",
-	"description": "The TSSLint VSCode Extension",
+	"displayName": "TypeScript Linter (TSL)",
+	"description": "The TSL VSCode Extension",
 	"author": "johnsoncodehk",
 	"publisher": "johnsoncodehk",
 	"engines": {
@@ -30,7 +30,7 @@
 		],
 		"typescriptServerPlugins": [
 			{
-				"name": "tsslint-typescript-plugin-bundled",
+				"name": "tsl-typescript-plugin-bundled",
 				"enableForWorkspaceTypeScriptVersions": true
 			}
 		]

--- a/packages/vscode/scripts/build.js
+++ b/packages/vscode/scripts/build.js
@@ -4,7 +4,7 @@ const esbuild = require('esbuild');
 
 esbuild.context({
 	entryPoints: {
-		'tsslint-typescript-plugin-bundled/index': './node_modules/@tsslint/typescript-plugin/index.js',
+		'tsl-typescript-plugin-bundled/index': './node_modules/@tsslint/typescript-plugin/index.js',
 	},
 	outdir: path.resolve(__dirname, '../node_modules'),
 	bundle: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,18 @@ importers:
         specifier: 0.0.8
         version: link:../config
 
+  packages/tsl:
+    dependencies:
+      '@tsslint/cli':
+        specifier: 0.0.8
+        version: link:../cli
+      '@tsslint/config':
+        specifier: 0.0.8
+        version: link:../config
+      '@tsslint/core':
+        specifier: 0.0.8
+        version: link:../core
+
   packages/typescript-plugin:
     dependencies:
       '@tsslint/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
 	},
 	"include": [ ],
 	"references": [
-		{ "path": "./packages/cli/tsconfig.json" },
-		{ "path": "./packages/config/tsconfig.json" },
+		{ "path": "./packages/tsl/tsconfig.json" },
 		{ "path": "./packages/typescript-plugin/tsconfig.json" },
 		{ "path": "./packages/vscode/tsconfig.json" },
 	],


### PR DESCRIPTION
Rename the project from TSSLint to TSL.

Thanks to @basarat for all the help with this, and thanks to @yyx990803 for suggesting the new name!