### PR TITLE
refactor(core): create TS program on demand

### DIFF
--- a/fixtures/define-a-plugin/tsslint.config.ts
+++ b/fixtures/define-a-plugin/tsslint.config.ts
@@ -15,12 +15,8 @@ export default defineConfig({
 });
 
 function createIngorePlugin(pattern: RegExp) {
-	return definePlugin(({ languageService }) => ({
-		resolveDiagnostics(fileName, results) {
-			const sourceFile = languageService.getProgram()?.getSourceFile(fileName);
-			if (!sourceFile) {
-				return results;
-			}
+	return definePlugin(() => ({
+		resolveDiagnostics(sourceFile, results) {
 			const comments = [...sourceFile.text.matchAll(pattern)];
 			const lines = new Set(comments.map(comment => sourceFile.getLineAndCharacterOfPosition(comment.index).line));
 			return results.filter(error => error.source !== 'tsslint' || !lines.has(sourceFile.getLineAndCharacterOfPosition(error.start).line - 1));

--- a/packages/eslint/lib/plugins/disableNextLine.ts
+++ b/packages/eslint/lib/plugins/disableNextLine.ts
@@ -10,15 +10,14 @@ export function create(
 	reportsUnusedComments = true,
 	reg = new RegExp(/\/\/\s*eslint-disable-next-line\b[ \t]*(?<ruleId>\S*)\b/g)
 ): Plugin {
-	return ({ languageService }) => ({
-		resolveDiagnostics(fileName, results) {
+	return () => ({
+		resolveDiagnostics(sourceFile, results) {
 			if (
 				!reportsUnusedComments &&
 				!results.some(error => error.source === 'tsslint')
 			) {
 				return results;
 			}
-			const sourceFile = languageService.getProgram()!.getSourceFile(fileName)!;
 			const disabledLines = new Map<number, CommentState>();
 			const disabledLinesByRules = new Map<string, Map<number, CommentState>>();
 			for (const comment of sourceFile.text.matchAll(reg)) {

--- a/packages/eslint/lib/plugins/showDocsAction.ts
+++ b/packages/eslint/lib/plugins/showDocsAction.ts
@@ -33,7 +33,7 @@ export function create(): Plugin {
 				collectMetadata(rules);
 				return rules;
 			},
-			resolveCodeFixes(fileName, diagnostic, codeFixes) {
+			resolveCodeFixes(sourceFile, diagnostic, codeFixes) {
 				const ruleMeta = ruleId2Meta.get(diagnostic.code as any);
 				if (!ruleMeta?.docs?.url) {
 					return codeFixes;
@@ -46,7 +46,7 @@ export function create(): Plugin {
 						fixName: 'Show documentation',
 						commands: [{
 							command: cmd,
-							file: fileName,
+							file: sourceFile.fileName,
 							url: ruleMeta.docs.url,
 						} satisfies Cmd],
 					},

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -30,8 +30,8 @@ export interface Plugin {
 
 export interface PluginInstance {
 	resolveRules?(fileName: string, rules: Rules): Rules;
-	resolveDiagnostics?(fileName: string, diagnostics: DiagnosticWithLocation[]): DiagnosticWithLocation[];
-	resolveCodeFixes?(fileName: string, diagnostic: Diagnostic, codeFixes: CodeFixAction[]): CodeFixAction[];
+	resolveDiagnostics?(sourceFile: SourceFile, diagnostics: DiagnosticWithLocation[]): DiagnosticWithLocation[];
+	resolveCodeFixes?(sourceFile: SourceFile, diagnostic: Diagnostic, codeFixes: CodeFixAction[]): CodeFixAction[];
 }
 
 export interface Rules {


### PR DESCRIPTION
If all rules do not use the TS program, the project TS program should not be created.

When property access is made to languageService, the TS program is considered to be required. The linter will enable type aware at this time and use the TS program for subsequent linting.

sourceFile is now passed to `resolveDiagnostics`, `resolveCodeFixes` to avoid the plugin needing to call `getProgram().getSourceFile()` causing type aware to be enabled unnecessarily.