### PR TITLE
feat(cli): cache mode

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -159,6 +159,7 @@ import fs = require('fs');
 					shouldRetry = false;
 					retry--;
 					if (Object.values(fileCache[1]).some(fixes => fixes > 0)) {
+						// Reset the cache if there are any fixes applied.
 						fileCache[1] = {};
 						fileCache[2].length = 0;
 						fileCache[3].length = 0;
@@ -178,6 +179,7 @@ import fs = require('fs');
 
 				if (newSnapshot) {
 					ts.sys.writeFile(fileName, newSnapshot.getText(0, newSnapshot.getLength()));
+					fileCache[0] = fs.statSync(fileName).mtimeMs;
 				}
 			}
 			else {

--- a/packages/cli/lib/cache.ts
+++ b/packages/cli/lib/cache.ts
@@ -1,15 +1,8 @@
 import core = require('@tsslint/core');
 import path = require('path');
 import fs = require('fs');
-import type * as ts from 'typescript';
 
-export type CacheData = Record<string /* fileName */, [
-	fileMtime: number,
-	ruleIds: string[],
-	result: ts.DiagnosticWithLocation[],
-	resolvedResult: ts.DiagnosticWithLocation[],
-	minimatchResult: Record<string, boolean>,
-]>;
+export type CacheData = Record<string /* fileName */, core.FileLintCache>;
 
 export function loadCache(
 	configFilePath: string,

--- a/packages/cli/lib/cache.ts
+++ b/packages/cli/lib/cache.ts
@@ -7,7 +7,8 @@ export type CacheData = Record<string /* fileName */, [
 	fileMtime: number,
 	ruleIds: string[],
 	result: ts.DiagnosticWithLocation[],
-	resolvedResult: ts.DiagnosticWithLocation[]
+	resolvedResult: ts.DiagnosticWithLocation[],
+	minimatchResult: Record<string, boolean>,
 ]>;
 
 export function loadCache(

--- a/packages/cli/lib/cache.ts
+++ b/packages/cli/lib/cache.ts
@@ -1,0 +1,41 @@
+import core = require('@tsslint/core');
+import path = require('path');
+import fs = require('fs');
+import type * as ts from 'typescript';
+
+export type CacheData = Record<string /* fileName */, [
+	fileMtime: number,
+	ruleIds: string[],
+	result: ts.DiagnosticWithLocation[],
+	resolvedResult: ts.DiagnosticWithLocation[]
+]>;
+
+export function loadCache(
+	configFilePath: string,
+	createHash: (path: string) => string = btoa
+): CacheData {
+	const outDir = core.getDotTsslintPath(configFilePath);
+	const cacheFileName = createHash(path.relative(outDir, configFilePath)) + '.cache.json';
+	const cacheFilePath = path.join(outDir, cacheFileName);
+	const cacheFileStat = fs.statSync(cacheFilePath, { throwIfNoEntry: false });
+	const configFileStat = fs.statSync(configFilePath, { throwIfNoEntry: false });
+	if (cacheFileStat?.isFile() && cacheFileStat.mtimeMs > (configFileStat?.mtimeMs ?? 0)) {
+		try {
+			return require(cacheFilePath);
+		} catch {
+			return {};
+		}
+	}
+	return {};
+}
+
+export function saveCache(
+	configFilePath: string,
+	cache: CacheData,
+	createHash: (path: string) => string = btoa
+): void {
+	const outDir = core.getDotTsslintPath(configFilePath);
+	const cacheFileName = createHash(path.relative(outDir, configFilePath)) + '.cache.json';
+	const cacheFilePath = path.join(outDir, cacheFileName);
+	fs.writeFileSync(cacheFilePath, JSON.stringify(cache));
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -90,11 +90,11 @@ export function createLinter(ctx: ProjectContext, config: Config | Config[], mod
 			let cacheableDiagnostics: ts.DiagnosticWithLocation[] = [];
 			let uncacheableDiagnostics: ts.DiagnosticWithLocation[] = [];
 			let debugInfo: ts.DiagnosticWithLocation | undefined;
-			let currentRuleLanguageServiceUsage = 0;
 			let currentRuleId: string;
 			let currentIssues = 0;
 			let currentFixes = 0;
 			let currentRefactors = 0;
+			let currentRuleLanguageServiceUsage = 0;
 			let sourceFile: ts.SourceFile | undefined;
 			let hasUncacheResult = false;
 

--- a/packages/core/lib/watch.ts
+++ b/packages/core/lib/watch.ts
@@ -13,7 +13,7 @@ export async function watchConfigFile(
 	logger: Pick<typeof console, 'log' | 'warn' | 'error'> = console
 ) {
 	let start: number;
-	const outDir = _path.resolve(configFilePath, '..', 'node_modules', '.tsslint');
+	const outDir = getDotTsslintPath(configFilePath);
 	const outFileName = createHash(_path.relative(outDir, configFilePath)) + '.mjs';
 	const outFile = _path.join(outDir, outFileName);
 	const resultHandler = async (result: esbuild.BuildResult) => {
@@ -136,4 +136,8 @@ export async function watchConfigFile(
 
 function isTsFile(path: string) {
 	return path.endsWith('.ts') || path.endsWith('.tsx') || path.endsWith('.cts') || path.endsWith('.mts');
+}
+
+export function getDotTsslintPath(configFilePath: string): string {
+	return _path.resolve(configFilePath, '..', 'node_modules', '.tsslint');
 }

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -228,7 +228,7 @@ function decorateLanguageService(
 							return diag;
 						});
 						if (config) {
-							linter = createLinter(projectContext, config, true);
+							linter = createLinter(projectContext, config, 'typescript-plugin');
 						}
 						info.project.refreshDiagnostics();
 					},


### PR DESCRIPTION
For non-type-aware rules, the results cached in `.tsslint` will be reused if the file has not changed.

Using the new `--force` flag will force disabled cache.

#### WIP

- [x] Support auto-fix when using cached diagnostics