### PR TITLE
feat(core): detect more reliably whether a rule requires type information

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -28,7 +28,7 @@ export interface Plugin {
 }
 
 export interface PluginInstance {
-	resolveRules?(fileName: string, rules: Rules): Rules;
+	resolveRules?(fileName: string, rules: Record<string, Rule>): Record<string, Rule>;
 	resolveDiagnostics?(sourceFile: SourceFile, diagnostics: DiagnosticWithLocation[]): DiagnosticWithLocation[];
 	resolveCodeFixes?(sourceFile: SourceFile, diagnostic: Diagnostic, codeFixes: CodeFixAction[]): CodeFixAction[];
 }


### PR DESCRIPTION
This PR is a rework of #28.

Simply determining whether the languageService attribute is accessed is not a reliable way to determine whether a rule requires type information, because some functions of languageService (such as getFormattingEdits) do not require type information, which results in unnecessary switching to type aware mode when executing some rules.

The new solution is to use syntax-only languageService. Since syntax-only languageService will throw when calling functions that require type information, we can catch the throw and determine whether the rule attempts to execute functions in languageService that require type information.