### PR TITLE
feat: add first party formatting support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"release:base": "lerna publish --exact --force-publish --yes --sync-workspace-lock",
 		"release:vscode": "cd packages/vscode && npm run release",
 		"start": "node packages/cli/bin/tsslint.js",
-		"lint": "node packages/cli/bin/tsslint.js --projects packages/*/tsconfig.json",
+		"lint": "node packages/cli/bin/tsslint.js --project packages/*/tsconfig.json",
 		"lint:fix": "npm run lint -- --fix",
 		"lint:fixtures": "node packages/cli/bin/tsslint.js --project fixtures/*/tsconfig.json --vue-project fixtures/meta-frameworks-support/tsconfig.json --mdx-project fixtures/meta-frameworks-support/tsconfig.json --astro-project fixtures/meta-frameworks-support/tsconfig.json"
 	},

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -213,7 +213,7 @@ class Project {
 	} else {
 		const projectsFlag = process.argv.find(arg => arg.endsWith('-projects'));
 		if (projectsFlag) {
-			clack.log.warn(lightYellow(`Use ${projectsFlag.slice(0, -1)} instead of ${projectsFlag}.`));
+			clack.log.warn(lightYellow(`Please use ${projectsFlag.slice(0, -1)} instead of ${projectsFlag} starting from version 1.5.0.`));
 		}
 		const options = [
 			{

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -375,13 +375,14 @@ class Project {
 					fileCache[0] = fileMtime;
 					fileCache[1] = {};
 					fileCache[2] = {};
+					fileCache[3] = false;
 				}
 				else {
 					cached++;
 				}
 			}
 			else {
-				project.cache[fileName] = fileCache = [fileMtime, {}, {}];
+				project.cache[fileName] = fileCache = [fileMtime, {}, {}, false];
 			}
 
 			let diagnostics = await linterWorker.lint(

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -34,7 +34,6 @@ if (process.argv.includes('--threads')) {
 }
 
 class Project {
-	tsconfig: string;
 	workers: ReturnType<typeof worker.create>[] = [];
 	fileNames: string[] = [];
 	options: ts.CompilerOptions = {};
@@ -44,17 +43,9 @@ class Project {
 	cache: cache.CacheData = {};
 
 	constructor(
-		tsconfigOption: string,
+		public tsconfig: string,
 		public languages: string[]
-	) {
-		try {
-			this.tsconfig = require.resolve(tsconfigOption, { paths: [process.cwd()] });
-		} catch {
-			console.error(lightRed(`No such file: ${tsconfigOption}`));
-			process.exit(1);
-		}
-
-	}
+	) { }
 
 	async init(
 		// @ts-expect-error
@@ -275,8 +266,14 @@ class Project {
 		}
 	}
 
-	for (const [tsconfig, languages] of tsconfigAndLanguages) {
-		projects.push(await new Project(tsconfig, languages).init(clack));
+	for (const [inputTsconfig, languages] of tsconfigAndLanguages) {
+		try {
+			const tsconfig = require.resolve(inputTsconfig, { paths: [process.cwd()] });
+			projects.push(await new Project(tsconfig, languages).init(clack));
+		} catch {
+			console.error(lightRed(`No such file: ${inputTsconfig}`));
+			process.exit(1);
+		}
 	}
 
 	spinner.start();

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -375,7 +375,6 @@ class Project {
 					fileCache[0] = fileMtime;
 					fileCache[1] = {};
 					fileCache[2] = {};
-					fileCache[3] = false;
 				}
 				else {
 					cached++;

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -434,16 +434,14 @@ class Project {
 	}
 
 	function getFormattingSettings() {
-		let formattingSettings: {
-			typescript: ts.FormatCodeSettings;
-			javascript: ts.FormatCodeSettings;
-		} | undefined;
+		let formattingSettings: ReturnType<typeof getVSCodeFormattingSettings> | undefined;
 
 		if (process.argv.includes('--vscode-settings')) {
 
 			formattingSettings = {
 				typescript: {},
 				javascript: {},
+				vue: {},
 			};
 
 			for (const section of ['typescript', 'javascript'] as const) {
@@ -485,6 +483,10 @@ class Project {
 			formattingSettings.javascript = {
 				...formattingSettings.javascript,
 				...vscodeSettings.javascript,
+			};
+			formattingSettings.vue = {
+				...formattingSettings.vue,
+				...vscodeSettings.vue,
 			};
 		}
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -407,13 +407,14 @@ class Project {
 				project.cache[fileName] = fileCache = [fileMtime, {}, {}];
 			}
 
-			let diagnostics!: ts.DiagnosticWithLocation[];
-
-			if (process.argv.includes('--fix')) {
-				diagnostics = await linterWorker.lintAndFix(fileName, fileCache);
-			} else {
-				diagnostics = await linterWorker.lint(fileName, fileCache);
-			}
+			let diagnostics = await linterWorker.lint(
+				fileName,
+				process.argv.includes('--fix'),
+				process.argv.includes('--format')
+					? {} // TODO
+					: undefined,
+				fileCache
+			);
 
 			diagnostics = diagnostics.filter(diagnostic => diagnostic.category !== ts.DiagnosticCategory.Suggestion);
 

--- a/packages/cli/lib/formatting.ts
+++ b/packages/cli/lib/formatting.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as json5 from 'json5';
+import type * as ts from 'typescript';
+
+export function getVSCodeFormattingSettings(settingsFile: string) {
+	const jsonc = fs.readFileSync(settingsFile, 'utf8');
+	const editorSettings = json5.parse(jsonc);
+	const jsSettings: ts.FormatCodeSettings = {};
+	const tsSettings: ts.FormatCodeSettings = {};
+
+	if ('editor.insertSpaces' in editorSettings) {
+		jsSettings.convertTabsToSpaces = !!editorSettings['editor.insertSpaces'];
+		tsSettings.convertTabsToSpaces = !!editorSettings['editor.insertSpaces'];
+	}
+	if ('editor.tabSize' in editorSettings) {
+		jsSettings.tabSize = editorSettings['editor.tabSize'];
+		tsSettings.tabSize = editorSettings['editor.tabSize'];
+	}
+	for (const key in editorSettings) {
+		if (key.startsWith('javascript.format.')) {
+			const settingKey = key.slice('javascript.format.'.length) as keyof ts.FormatCodeSettings;
+			// @ts-expect-error
+			jsSettings[settingKey] = editorSettings[key];
+		}
+		else if (key.startsWith('typescript.format.')) {
+			const settingKey = key.slice('typescript.format.'.length) as keyof ts.FormatCodeSettings;
+			// @ts-expect-error
+			tsSettings[settingKey] = editorSettings[key];
+		}
+	}
+
+	return {
+		javascript: jsSettings,
+		typescript: tsSettings,
+	};
+}

--- a/packages/cli/lib/formatting.ts
+++ b/packages/cli/lib/formatting.ts
@@ -7,6 +7,9 @@ export function getVSCodeFormattingSettings(settingsFile: string) {
 	const editorSettings = json5.parse(jsonc);
 	const jsSettings: ts.FormatCodeSettings = {};
 	const tsSettings: ts.FormatCodeSettings = {};
+	const vueSettings: {
+		'script.initialIndent'?: boolean;
+	} = {};
 
 	if ('editor.insertSpaces' in editorSettings) {
 		jsSettings.convertTabsToSpaces = !!editorSettings['editor.insertSpaces'];
@@ -28,9 +31,30 @@ export function getVSCodeFormattingSettings(settingsFile: string) {
 			tsSettings[settingKey] = editorSettings[key];
 		}
 	}
+	if ('vue.format.script.initialIndent' in editorSettings) {
+		vueSettings['script.initialIndent'] = !!editorSettings['vue.format.script.initialIndent'];
+	}
 
 	return {
 		javascript: jsSettings,
 		typescript: tsSettings,
+		vue: vueSettings,
 	};
+}
+
+export function computeInitialIndent(content: string, i: number, baseTabSize?: number) {
+	let nChars = 0;
+	const tabSize = baseTabSize || 4;
+	while (i < content.length) {
+		const ch = content.charAt(i);
+		if (ch === ' ') {
+			nChars++;
+		} else if (ch === '\t') {
+			nChars += tabSize;
+		} else {
+			break;
+		}
+		i++;
+	}
+	return Math.floor(nChars / tabSize);
 }

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -363,13 +363,7 @@ function lint(fileName: string, fix: boolean, fileCache: core.FileLintCache) {
 			}
 
 			if (script?.generated) {
-				const sourceFile = ts.createSourceFile(
-					fileName,
-					script.snapshot.getText(0, script.snapshot.getLength()),
-					ts.ScriptTarget.Latest,
-					true,
-					ts.ScriptKind.Deferred
-				);
+				let sourceFile: ts.SourceFile | undefined;
 				for (const code of forEachEmbeddedCode(script.generated.root)) {
 					if (
 						(
@@ -390,6 +384,13 @@ function lint(fileName: string, fix: boolean, fileCache: core.FileLintCache) {
 
 						if (settings.tabSize !== undefined) {
 							const firstMapping = code.mappings[0];
+							sourceFile ??= ts.createSourceFile(
+								fileName,
+								script.snapshot.getText(0, script.snapshot.getLength()),
+								ts.ScriptTarget.Latest,
+								true,
+								ts.ScriptKind.Deferred
+							);
 							const line = sourceFile.getLineAndCharacterOfPosition(firstMapping.sourceOffsets[0]).line;
 							const offset = sourceFile.getPositionOfLineAndCharacter(line, 0);
 							let initialIndentLevel = computeInitialIndent(

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -288,11 +288,16 @@ function lint(fileName: string, fix: boolean, fileCache: core.FileLintCache) {
 	}
 
 	if (newSnapshot) {
-		ts.sys.writeFile(fileName, newSnapshot.getText(0, newSnapshot.getLength()));
-		fileCache[0] = fs.statSync(fileName).mtimeMs;
-		fileCache[1] = {};
-		fileCache[2] = {};
-		shouldCheck = true;
+		const newText = newSnapshot.getText(0, newSnapshot.getLength());
+		const oldText = ts.sys.readFile(fileName);
+		if (newText !== oldText) {
+			ts.sys.writeFile(fileName, newSnapshot.getText(0, newSnapshot.getLength()));
+			fileCache[0] = fs.statSync(fileName).mtimeMs;
+			fileCache[1] = {};
+			fileCache[2] = {};
+			fileCache[3] = false;
+			shouldCheck = true;
+		}
 	}
 
 	if (shouldCheck) {

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -222,6 +222,7 @@ async function setup(
 function lint(fileName: string, fix: boolean, formatSettings: ts.FormatCodeSettings | undefined, fileCache: core.FileLintCache) {
 	let newSnapshot: ts.IScriptSnapshot | undefined;
 	let diagnostics!: ts.DiagnosticWithLocation[];
+	let shouldCheck = true;
 
 	if (fix) {
 		if (Object.values(fileCache[1]).some(([hasFix]) => hasFix)) {
@@ -230,6 +231,7 @@ function lint(fileName: string, fix: boolean, formatSettings: ts.FormatCodeSetti
 			fileCache[2] = {};
 		}
 		diagnostics = linter.lint(fileName, fileCache);
+		shouldCheck = false;
 
 		let fixes = linter
 			.getCodeFixes(fileName, 0, Number.MAX_VALUE, diagnostics, fileCache[2])
@@ -277,7 +279,10 @@ function lint(fileName: string, fix: boolean, formatSettings: ts.FormatCodeSetti
 		fileCache[0] = fs.statSync(fileName).mtimeMs;
 		fileCache[1] = {};
 		fileCache[2] = {};
+		shouldCheck = true;
+	}
 
+	if (shouldCheck) {
 		diagnostics = linter.lint(fileName, fileCache);
 	}
 

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -255,6 +255,7 @@ function lint(fileName: string, fix: boolean, fileCache: core.FileLintCache) {
 
 		const textChanges = core.combineCodeFixes(fileName, fixes);
 		if (textChanges.length) {
+			fileCache[3] = false;
 			const oldSnapshot = snapshots.get(fileName)!;
 			newSnapshot = core.applyTextChanges(oldSnapshot, textChanges);
 			snapshots.set(fileName, newSnapshot);
@@ -262,7 +263,8 @@ function lint(fileName: string, fix: boolean, fileCache: core.FileLintCache) {
 			projectVersion++;
 		}
 
-		if (fmtSettings) {
+		if (!fileCache[3] && fmtSettings) {
+			fileCache[3] = true;
 			const sourceFile: ts.SourceFile = (originalSyntaxOnlyService as any).getNonBoundSourceFile(fileName);
 			const linterEdits = linter.format(sourceFile, fileCache[2]);
 			if (linterEdits.length) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
 		"@tsslint/core": "1.4.6",
 		"@volar/language-core": "~2.4.0",
 		"@volar/typescript": "~2.4.0",
-		"glob": "^10.4.1"
+		"glob": "^10.4.1",
+		"json5": "^2.2.3"
 	},
 	"peerDependencies": {
 		"typescript": "*"

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -24,6 +24,7 @@ export type FileLintCache = [
 		[hasFix: boolean, diagnostics: ts.DiagnosticWithLocation[]]
 	>,
 	minimatchResult: Record<string, boolean>,
+	formated: boolean,
 ];
 
 export type Linter = ReturnType<typeof createLinter>;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,7 +1,16 @@
 export * from './lib/build';
 export * from './lib/watch';
 
-import type { Config, ProjectContext, Reporter, Rule, RuleContext, Rules } from '@tsslint/types';
+import type {
+	Config,
+	ProjectContext,
+	Reporter,
+	Rule,
+	RuleContext,
+	Rules,
+	FormattingProcess,
+	FormattingContext,
+} from '@tsslint/types';
 import type * as ts from 'typescript';
 
 import ErrorStackParser = require('error-stack-parser');
@@ -21,6 +30,7 @@ export type Linter = ReturnType<typeof createLinter>;
 
 export function createLinter(
 	ctx: ProjectContext,
+	rootDir: string,
 	config: Config | Config[],
 	mode: 'cli' | 'typescript-plugin',
 	syntaxOnlyLanguageService?: ts.LanguageService & {
@@ -29,6 +39,7 @@ export function createLinter(
 ) {
 	const ts = ctx.typescript;
 	const fileRules = new Map<string, Record<string, Rule>>();
+	const fileFmtProcesses = new Map<string, FormattingProcess[]>();
 	const fileConfigs = new Map<string, typeof configs>();
 	const lintResults = new Map<
 		/* fileName */ string,
@@ -45,12 +56,12 @@ export function createLinter(
 			}[],
 		]
 	>();
-	const basePath = path.dirname(ctx.configFile);
 	const configs = (Array.isArray(config) ? config : [config])
 		.map(config => ({
 			include: config.include ?? [],
 			exclude: config.exclude ?? [],
 			rules: config.rules ?? {},
+			formatting: config.formatting ?? [],
 			plugins: (config.plugins ?? []).map(plugin => plugin(ctx)),
 		}));
 	const normalizedPath = new Map<string, string>();
@@ -60,6 +71,47 @@ export function createLinter(
 	let shouldEnableTypeAware = false;
 
 	return {
+		format(sourceFile: ts.SourceFile, minimatchCache?: FileLintCache[2]): ts.TextChange[] {
+			const changes: ts.TextChange[] = [];
+			const processes = getFileFormattingProcesses(sourceFile.fileName, minimatchCache);
+			const tmpChanges: ts.TextChange[] = [];
+			const fmtCtx: FormattingContext = {
+				typescript: ts,
+				sourceFile,
+				insert(pos, text) {
+					tmpChanges.push({ span: { start: pos, length: 0 }, newText: text });
+				},
+				remove(start, end) {
+					tmpChanges.push({ span: { start, length: end - start }, newText: '' });
+				},
+				replace(start, end, text) {
+					tmpChanges.push({ span: { start, length: end - start }, newText: text });
+				},
+			};
+			for (const process of processes) {
+				process(fmtCtx);
+				if (tmpChanges.every(a => {
+					const aStart = a.span.start;
+					const aEnd = aStart + a.span.length;
+					for (const b of changes) {
+						const bStart = b.span.start;
+						const bEnd = bStart + b.span.length;
+						if (
+							(bStart >= aEnd && bStart > aStart)
+							|| (bEnd <= aStart && bEnd < aEnd)
+						) {
+							continue;
+						}
+						return false;
+					}
+					return true;
+				})) {
+					changes.push(...tmpChanges);
+				}
+				tmpChanges.length = 0;
+			}
+			return changes;
+		},
 		lint(fileName: string, cache?: FileLintCache): ts.DiagnosticWithLocation[] {
 			let currentRuleId: string;
 			let shouldRetry = false;
@@ -369,6 +421,19 @@ export function createLinter(
 		getConfigs: getFileConfigs,
 	};
 
+	function getFileFormattingProcesses(fileName: string, minimatchCache: undefined | FileLintCache[2]) {
+		let processes = fileFmtProcesses.get(fileName);
+		if (!processes) {
+			processes = [];
+			const configs = getFileConfigs(fileName, minimatchCache);
+			for (const config of configs) {
+				processes.push(...config.formatting);
+			}
+			fileFmtProcesses.set(fileName, processes);
+		}
+		return processes;
+	}
+
 	function getFileRules(fileName: string, minimatchCache: undefined | FileLintCache[2]) {
 		let rules = fileRules.get(fileName);
 		if (!rules) {
@@ -421,7 +486,7 @@ export function createLinter(
 				}
 				let normalized = normalizedPath.get(pattern);
 				if (!normalized) {
-					normalized = ts.server.toNormalizedPath(path.resolve(basePath, pattern));
+					normalized = ts.server.toNormalizedPath(path.resolve(rootDir, pattern));
 					normalizedPath.set(pattern, normalized);
 				}
 				const res = minimatch.minimatch(fileName, normalized);

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -9,11 +9,9 @@ import type {
 } from 'typescript';
 
 export interface ProjectContext {
-	configFile: string;
 	typescript: typeof import('typescript');
 	languageServiceHost: LanguageServiceHost;
 	languageService: LanguageService;
-	tsconfig: string;
 }
 
 export interface Config {
@@ -21,10 +19,23 @@ export interface Config {
 	exclude?: string[];
 	rules?: Rules;
 	plugins?: Plugin[];
+	formatting?: FormattingProcess[];
 }
 
 export interface Plugin {
-	(projectContext: ProjectContext): PluginInstance;
+	(ctx: ProjectContext): PluginInstance;
+}
+
+export interface FormattingProcess {
+	(ctx: FormattingContext): void;
+}
+
+export interface FormattingContext {
+	typescript: typeof import('typescript');
+	sourceFile: SourceFile;
+	insert(pos: number, text: string): void;
+	remove(start: number, end: number): void;
+	replace(start: number, end: number, text: string): void;
 }
 
 export interface PluginInstance {
@@ -38,7 +49,7 @@ export interface Rules {
 }
 
 export interface Rule {
-	(context: RuleContext): void;
+	(ctx: RuleContext): void;
 }
 
 export interface RuleContext {

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -11,15 +11,17 @@ const plugin: ts.server.PluginModuleFactory = modules => {
 	const { typescript: ts } = modules;
 	const pluginModule: ts.server.PluginModule = {
 		create(info) {
-			if (info.project.projectKind === ts.server.ProjectKind.Configured) {
-				let decorator = languageServiceDecorators.get(info.project);
-				if (!decorator) {
+			let decorator = languageServiceDecorators.get(info.project);
+			if (!decorator) {
+				if (info.project.projectKind === ts.server.ProjectKind.Configured) {
 					const tsconfig = info.project.getProjectName();
-					decorator = decorateLanguageService(ts, tsconfig, info);
-					languageServiceDecorators.set(info.project, decorator);
+					decorator = decorateLanguageService(ts, path.dirname(tsconfig), info);
+				} else {
+					decorator = decorateLanguageService(ts, info.project.getCurrentDirectory(), info);
 				}
-				decorator.update();
+				languageServiceDecorators.set(info.project, decorator);
 			}
+			decorator.update();
 			return info.languageService;
 		},
 	};
@@ -30,7 +32,7 @@ export = plugin;
 
 function decorateLanguageService(
 	ts: typeof import('typescript'),
-	tsconfig: string,
+	projectRoot: string,
 	info: ts.server.PluginCreateInfo
 ) {
 	const {
@@ -39,8 +41,11 @@ function decorateLanguageService(
 		getCombinedCodeFix,
 		getApplicableRefactors,
 		getEditsForRefactor,
+		getFormattingEditsForDocument,
+		getFormattingEditsForRange,
 	} = info.languageService;
-
+	const getScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
+	const getScriptVersion = info.languageServiceHost.getScriptVersion.bind(info.languageServiceHost);
 	const projectFileNameKeys = new Set<string>();
 
 	let configFile: string | undefined;
@@ -48,7 +53,96 @@ function decorateLanguageService(
 	let configFileDiagnostics: Omit<ts.Diagnostic, 'file' | 'start' | 'length' | 'source'>[] = [];
 	let config: Config | Config[] | undefined;
 	let linter: core.Linter | undefined;
+	let formattingSnapshot: ts.IScriptSnapshot | undefined;
+	let formattingSnapshotVersion = 0;
 
+	info.languageServiceHost.getScriptSnapshot = fileName => {
+		if (formattingSnapshot) {
+			return formattingSnapshot;
+		}
+		return getScriptSnapshot(fileName);
+	};
+	info.languageServiceHost.getScriptVersion = fileName => {
+		if (formattingSnapshot) {
+			return `tsslint-fmt-${formattingSnapshotVersion++}`;
+		}
+		return getScriptVersion(fileName);
+	};
+
+	info.languageService.getFormattingEditsForDocument = (fileName, options) => {
+		if (linter) {
+			try {
+				const sourceFile: ts.SourceFile = (info.languageService as any).getNonBoundSourceFile(fileName);
+				const linterEdits = linter.format(sourceFile);
+				if (linterEdits.length) {
+					const originalLength = sourceFile.text.length;
+					let text = sourceFile.text;
+					for (const edit of linterEdits.sort((a, b) => (b.span.start + b.span.length) - (a.span.start + a.span.length))) {
+						text = text.slice(0, edit.span.start) + edit.newText + text.slice(edit.span.start + edit.span.length);
+					}
+					formattingSnapshot = ts.ScriptSnapshot.fromString(text);
+					const serviceEdits = getFormattingEditsForDocument(fileName, options);
+					formattingSnapshot = undefined;
+					if (serviceEdits.length) {
+						for (const edit of serviceEdits.sort((a, b) => (b.span.start + b.span.length) - (a.span.start + a.span.length))) {
+							text = text.slice(0, edit.span.start) + edit.newText + text.slice(edit.span.start + edit.span.length);
+						}
+						return [{
+							span: { start: 0, length: originalLength },
+							newText: text,
+						}];
+					}
+					else {
+						return linterEdits;
+					}
+				}
+			} catch {
+				debugger;
+			}
+		}
+		return getFormattingEditsForDocument(fileName, options);
+	};
+	info.languageService.getFormattingEditsForRange = (fileName, start, end, options) => {
+		if (linter) {
+			try {
+				const sourceFile: ts.SourceFile = (info.languageService as any).getNonBoundSourceFile(fileName);
+				const linterEdits = linter.format(sourceFile);
+				if (linterEdits.length) {
+					const originalLength = sourceFile.text.length;
+					let text = sourceFile.text;
+					let formattingStart = start;
+					let formattingEnd = end;
+					for (const edit of linterEdits.sort((a, b) => (b.span.start + b.span.length) - (a.span.start + a.span.length))) {
+						text = text.slice(0, edit.span.start) + edit.newText + text.slice(edit.span.start + edit.span.length);
+						if (edit.span.start < start) {
+							formattingStart += edit.newText.length - edit.span.length;
+						}
+						if (edit.span.start + edit.span.length < end) {
+							formattingEnd += edit.newText.length - edit.span.length;
+						}
+					}
+					formattingSnapshot = ts.ScriptSnapshot.fromString(text);
+					const serviceEdits = getFormattingEditsForRange(fileName, formattingStart, formattingEnd, options);
+					formattingSnapshot = undefined;
+					if (serviceEdits.length) {
+						for (const edit of serviceEdits.sort((a, b) => (b.span.start + b.span.length) - (a.span.start + a.span.length))) {
+							text = text.slice(0, edit.span.start) + edit.newText + text.slice(edit.span.start + edit.span.length);
+						}
+						return [{
+							span: { start: 0, length: originalLength },
+							newText: text,
+						}];
+					}
+					else {
+						return linterEdits;
+					}
+				}
+			} catch {
+				debugger;
+			}
+		}
+		return getFormattingEditsForRange(fileName, start, end, options);
+	};
 	info.languageService.getSemanticDiagnostics = fileName => {
 		let result = getSemanticDiagnostics(fileName);
 		if (!isProjectFileName(fileName)) {
@@ -131,7 +225,7 @@ function decorateLanguageService(
 
 	async function update() {
 
-		const newConfigFile = ts.findConfigFile(path.dirname(tsconfig), ts.sys.fileExists, 'tsslint.config.ts');
+		const newConfigFile = ts.findConfigFile(projectRoot, ts.sys.fileExists, 'tsslint.config.ts');
 
 		if (newConfigFile !== configFile) {
 			configFile = newConfigFile;
@@ -145,11 +239,9 @@ function decorateLanguageService(
 			}
 
 			const projectContext: ProjectContext = {
-				configFile,
 				languageServiceHost: info.languageServiceHost,
 				languageService: info.languageService,
 				typescript: ts,
-				tsconfig: ts.server.toNormalizedPath(tsconfig),
 			};
 
 			try {
@@ -193,7 +285,7 @@ function decorateLanguageService(
 								initSourceMapSupport();
 								const mtime = ts.sys.getModifiedTime?.(builtConfig)?.getTime() ?? Date.now();
 								config = (await import(url.pathToFileURL(builtConfig).toString() + '?tsslint_time=' + mtime)).default;
-								linter = core.createLinter(projectContext, config!, 'typescript-plugin');
+								linter = core.createLinter(projectContext, path.dirname(configFile!), config!, 'typescript-plugin');
 							} catch (err) {
 								config = undefined;
 								linter = undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       glob:
         specifier: ^10.4.1
         version: 10.4.5
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       typescript:
         specifier: '*'
         version: 5.7.2


### PR DESCRIPTION
Integrated with typescript's built-in formatting, you can now use the `--fix` flag with the `--vscode-settings` flag to format in the CLI.

Example: `tsslint --project tsconfig.json --fix --vscode-settings .vscode/settings.json`

#### Why `--vscode-settings` is necessary

TSSLint CLI needs to obtain the `javascript.format.*`, `typescript.format.*`, `vue.format.*` settings from the editor settings to ensure consistent formatting behavior with the editor.

#### What about other editor settings file?

Currently only VSCode is supported. If you need to work with settings files from other editors, please open a feature request and we will add support soon.

#### Can Vue files be formatted?

Now supports formatting scripts in Vue files and TS codes in templates, but will not format CSS/HTML codes in Vue files.

#### Will formatting and linting conflict?

Formatting is always performed after applying linting auto fix. These are two independent processes, so there will be no conflict.

#### How do custom format rules work in this way?

You should no longer write custom formatting behavior as rules, instead you should use the new Formatting Preprocess API in this PR, which will ensure you get native DX (When performing formatting in VSCode, your custom formatting preprocess will silently cooperate with the tsserver formatter) in your IDE and prevent conflicts between formatting and linting.

For code examples of formatting preprocess API, please refer to: https://github.com/johnsoncodehk/tsslint-config/blob/c31017be91a3585f7a5d67e3366e69311b6563f1/index.ts#L170-L324