### PR TITLE
Improve glob pattern to match more tsconfig variants

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -158,7 +158,7 @@ class Project {
 			process.exit(1);
 		}
 
-		const tsconfigOptions = glob.sync('**/{tsconfig.json,jsconfig.json}');
+		const tsconfigOptions = glob.sync('**/{tsconfig.json,tsconfig.*.json,jsconfig.json}');
 
 		let options = await Promise.all(
 			tsconfigOptions.map(async tsconfigOption => {


### PR DESCRIPTION
This PR improves the glob pattern to match more tsconfig files, including common suffixes like `tsconfig.app.json` and `tsconfig.node.json`. This aligns better with project structures such as the default setup in `create-vue`.

https://github.com/vuejs/create-vue/tree/main/template/tsconfig/base

---
Thanks for the great tool! I think it's great for refactoring legacy code with a large number of Vue SFC files.