### PR TITLE
chore: add `.DS_Store` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 packages/*/index.js
 packages/*/lib/**/*.js
 .tsslint/
+.DS_Store


### PR DESCRIPTION
Include `.DS_Store` in the `.gitignore` file to prevent macOS system files from being tracked in the repository.