### PR TITLE
feat(config): add `isCLI` helper function

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -8,6 +8,8 @@ import fs = require('fs');
 import os = require('os');
 import languagePlugins = require('./lib/languagePlugins.js');
 
+process.env.TSSLINT_CLI = '1';
+
 const _reset = '\x1b[0m';
 const purple = (s: string) => '\x1b[35m' + s + _reset;
 const cyan = (s: string) => '\x1b[36m' + s + _reset;

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -14,3 +14,7 @@ export function definePlugin(plugin: Plugin) {
 export function defineConfig(config: Config | Config[]) {
 	return config;
 }
+
+export function isCLI() {
+	return !!process.env.TSSLINT_CLI;
+}


### PR DESCRIPTION
Resolves #54

Added the `isCLI` helper function to differentiate configuration between CLI and IDE.

```ts
import { isCLI } from '@tsslint/config';

export default isCLI() ? {
	// CLI config...
} : {
	// IDE config...
}
```