### PR TITLE
refactor: disallow severity configuration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To enable TSSLint in VSCode, follow these steps:
 
 ### Create a Rule
 
-To create a rule, you need to define a function that receives the context of the current diagnostic task. Within this function, you can call `reportError()` or `reportWarning()` to report an error.
+To create a rule, you need to define a function that receives the context of the current diagnostic task. Within this function, you can call `report()` to report an error.
 
 As an example, let's create a `no-console` rule under `[project root]/rules/`.
 
@@ -71,14 +71,14 @@ Here's the code for `[project root]/rules/noConsoleRule.ts`:
 import { defineRule } from '@tsslint/config';
 
 export function create() {
-	return defineRule(({ typescript: ts, sourceFile, reportWarning }) => {
+	return defineRule(({ typescript: ts, sourceFile, report }) => {
 		ts.forEachChild(sourceFile, function cb(node) {
 			if (
 				ts.isPropertyAccessExpression(node) &&
 				ts.isIdentifier(node.expression) &&
 				node.expression.text === 'console'
 			) {
-				reportWarning(
+				report(
 					`Calls to 'console.x' are not allowed.`,
 					node.parent.getStart(sourceFile),
 					node.parent.getEnd()
@@ -114,7 +114,7 @@ export default defineConfig({
 });
 ```
 
-After saving the config file, you will notice that `console.log` is now reporting errors in the editor. The error message will also display the specific line of code where the error occurred. Clicking on the error message will take you to line 11 in `noConsoleRule.ts`, where the `reportWarning()` code is located.
+After saving the config file, you will notice that `console.log` is now reporting errors in the editor. The error message will also display the specific line of code where the error occurred. Clicking on the error message will take you to line 11 in `noConsoleRule.ts`, where the `report()` code is located.
 
 > Full example: https://github.com/johnsoncodehk/tsslint/tree/master/fixtures/define-a-rule
 

--- a/fixtures/noConsoleRule.ts
+++ b/fixtures/noConsoleRule.ts
@@ -1,14 +1,14 @@
 import { defineRule } from '@tsslint/config';
 
 export function create() {
-	return defineRule(({ typescript: ts, sourceFile, reportWarning }) => {
+	return defineRule(({ typescript: ts, sourceFile, report }) => {
 		ts.forEachChild(sourceFile, function cb(node) {
 			if (
 				ts.isPropertyAccessExpression(node) &&
 				ts.isIdentifier(node.expression) &&
 				node.expression.text === 'console'
 			) {
-				reportWarning(
+				report(
 					`Calls to 'console.x' are not allowed.`,
 					node.parent.getStart(sourceFile),
 					node.parent.getEnd()

--- a/packages/eslint/lib/dtsGenerate.ts
+++ b/packages/eslint/lib/dtsGenerate.ts
@@ -17,8 +17,7 @@ export async function generate(
 	let dts = '';
 	let defId = 0;
 
-	line(`export type S = 'off' | 'error' | 'warn' | 'suggestion' | 'message' | 0 | 1 | 2 | 3;`);
-	line(`export type O<T extends any[]> = S | [S, ...options: T];`);
+	line(`export type O<T extends any[]> = boolean | [boolean, ...options: T];`);
 	line(``);
 	line(`export interface ESLintRulesConfig {`);
 	indentLevel++;

--- a/packages/eslint/lib/types.ts
+++ b/packages/eslint/lib/types.ts
@@ -1,5 +1,4 @@
-export type S = 'off' | 'error' | 'warn' | 'suggestion' | 'message' | 0 | 1 | 2 | 3;
-export type O<T extends any[]> = S | [S, ...options: T];
+export type O<T extends any[]> = boolean | [boolean, ...options: T];
 
 export interface ESLintRulesConfig {
 	[key: string]: O<any[]>;

--- a/packages/tslint/index.ts
+++ b/packages/tslint/index.ts
@@ -1,30 +1,20 @@
 import type * as TSSLint from '@tsslint/types';
 import type * as TSLint from 'tslint';
-import type * as ts from 'typescript';
 
 type TSLintRule = import('tslint/lib/language/rule/rule').RuleConstructor;
 
 export function convertRule<T extends Partial<TSLintRule> | TSLintRule>(
 	Rule: T,
 	ruleArguments: any[] = [],
-	severity: ts.DiagnosticCategory =
-		!Rule.metadata || Rule.metadata.type === 'functionality' || Rule.metadata.type === 'typescript' ? 1 satisfies ts.DiagnosticCategory.Error
-			: Rule.metadata.type === 'maintainability' || Rule.metadata.type === 'style' ? 0 satisfies ts.DiagnosticCategory.Warning
-				: Rule.metadata.type === 'formatting' ? 2 satisfies ts.DiagnosticCategory.Suggestion
-					: 3 satisfies ts.DiagnosticCategory.Message
 ): TSSLint.Rule {
 	const rule = new (Rule as TSLintRule)({
 		ruleName: Rule.metadata?.ruleName ?? 'unknown',
 		ruleArguments,
-		ruleSeverity: severity === 1 ? 'error' : severity === 2 ? 'warning' : 'off',
+		ruleSeverity: 'warning',
 		disabledIntervals: [],
 	}) as TSLint.IRule | TSLint.ITypedRule;
-	return ({ typescript: ts, sourceFile, languageService, reportError, reportWarning, reportSuggestion }) => {
+	return ({ sourceFile, languageService, report }) => {
 		let lastFailure: TSLint.RuleFailure | undefined;
-		const report =
-			severity === ts.DiagnosticCategory.Error ? reportError
-				: severity === ts.DiagnosticCategory.Warning ? reportWarning
-					: reportSuggestion;
 		const onAddFailure = (failure: TSLint.RuleFailure) => {
 			if (lastFailure === failure) {
 				return;
@@ -34,7 +24,7 @@ export function convertRule<T extends Partial<TSLintRule> | TSLintRule>(
 				failure.getFailure(),
 				failure.getStartPosition().getPosition(),
 				failure.getEndPosition().getPosition(),
-				false
+				Number.MAX_VALUE
 			);
 			if (failure.hasFix()) {
 				const fix = failure.getFix();

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -44,19 +44,19 @@ export interface RuleContext {
 	languageServiceHost: LanguageServiceHost;
 	languageService: LanguageService;
 	sourceFile: SourceFile;
-	report(message: string, start: number, end: number, stackOffset?: number | false): Reporter;
+	report(message: string, start: number, end: number, stackOffset?: number): Reporter;
 	/**
 	 * @deprecated Use `report` instead.
 	 */
-	reportError(message: string, start: number, end: number, stackOffset?: number | false): Reporter;
+	reportError(message: string, start: number, end: number, stackOffset?: number): Reporter;
 	/**
 	 * @deprecated Use `report` instead.
 	 */
-	reportWarning(message: string, start: number, end: number, stackOffset?: number | false): Reporter;
+	reportWarning(message: string, start: number, end: number, stackOffset?: number): Reporter;
 	/**
 	 * @deprecated Use `report` instead.
 	 */
-	reportSuggestion(message: string, start: number, end: number, stackOffset?: number | false): Reporter;
+	reportSuggestion(message: string, start: number, end: number, stackOffset?: number): Reporter;
 }
 
 export interface Reporter {


### PR DESCRIPTION
This project is positioned as a plugin for tsserver rather than a standalone linter, so the ability to distinguish between tsslint errors and TS errors should be considered a feature.

This PR deprecates `reportWarning`, `reportError`, and `reportSuggestion`, replacing them with a single `report` function. Linting reports will appear in blue in the IDE to differentiate them from TS errors.