### PR TITLE
feat(config): add `createCategoryPlugin` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ export default defineConfig({
 	},
 	plugins: [
 		({ typescript: ts }) => ({
-			resolveDiagnostics(_fileName, diagnostics) {
+			resolveDiagnostics(file, diagnostics) {
 				for (const diagnostic of diagnostics) {
 					if (diagnostic.code === 'no-console') {
 						diagnostic.category = ts.DiagnosticCategory.Error;
@@ -170,7 +170,7 @@ You can also lint multiple projects at once:
 
 ```sh
 npx tsslint --project packages/*/tsconfig.json
-npx tsslint --project packages/pkg-a/tsconfig.json packages/pkg-b/tsconfig.json
+npx tsslint --project {packages/pkg-a/tsconfig.json,packages/pkg-b/tsconfig.json}
 ```
 
 This command will run the linter on all TypeScript projects located in the subdirectories of the `packages` directory. Each subdirectory should contain a `tsconfig.json` file defining a TypeScript project. Any linting errors will be output to the console.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"release:base": "lerna publish --exact --force-publish --yes --sync-workspace-lock",
 		"release:vscode": "cd packages/vscode && npm run publish:all",
 		"start": "node packages/cli/bin/tsslint.js",
-		"lint": "node packages/cli/bin/tsslint.js --project packages/*/tsconfig.json",
+		"lint": "node packages/cli/bin/tsslint.js --project {tsconfig.json,packages/*/tsconfig.json}",
 		"lint:fix": "npm run lint -- --fix",
 		"lint:fixtures": "node packages/cli/bin/tsslint.js --project fixtures/*/tsconfig.json --vue-project fixtures/meta-frameworks-support/tsconfig.json --mdx-project fixtures/meta-frameworks-support/tsconfig.json --astro-project fixtures/meta-frameworks-support/tsconfig.json --ts-macro-project fixtures/meta-frameworks-support/tsconfig.json"
 	},

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -1,4 +1,5 @@
 export * from '@tsslint/types';
+export { create as createCategoryPlugin } from './lib/plugins/category.js';
 export { create as createDiagnosticsPlugin } from './lib/plugins/diagnostics.js';
 export { create as createIgnorePlugin } from './lib/plugins/ignore.js';
 

--- a/packages/config/lib/plugins/category.ts
+++ b/packages/config/lib/plugins/category.ts
@@ -1,0 +1,34 @@
+import type { Plugin } from '@tsslint/types';
+import type * as ts from 'typescript';
+
+import minimatch = require('minimatch');
+
+export function create(config: Record<string, ts.DiagnosticCategory>, source = 'tsslint'): Plugin {
+	const matchCache = new Map<string | number, ts.DiagnosticCategory | undefined>();
+	return () => ({
+		resolveDiagnostics(_file, diagnostics) {
+			for (const diagnostic of diagnostics) {
+				if (diagnostic.source !== source) {
+					continue;
+				}
+				const category = match(diagnostic.code.toString());
+				if (category !== undefined) {
+					diagnostic.category = category;
+				}
+			}
+			return diagnostics;
+		}
+	});
+	function match(code: string) {
+		if (matchCache.has(code)) {
+			return matchCache.get(code);
+		}
+		for (const pattern in config) {
+			const category = config[pattern];
+			if (minimatch.minimatch(code, pattern, { dot: true })) {
+				matchCache.set(code, category);
+				return category;
+			}
+		}
+	}
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@tsslint/types": "2.0.2",
+		"minimatch": "^10.0.1",
 		"ts-api-utils": "^2.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@tsslint/types':
         specifier: 2.0.2
         version: link:../types
+      minimatch:
+        specifier: ^10.0.1
+        version: 10.0.3
       ts-api-utils:
         specifier: ^2.0.0
         version: 2.1.0(typescript@5.9.2)


### PR DESCRIPTION
Added `createCategoryPlugin` API for modifying diagnostic categories.

The following example will modify all TypeScript-ESLint reports to "suggestion" in the CLI to prevent throwing.

```ts
import { defineConfig, isCLI, createCategoryPlugin } from '@tsslint/config';
import { defineRules } from '@tsslint/eslint';

export default defineConfig({
	plugins: isCLI()
		? [
			// 0: Warning, 1: Error, 2: Suggestion, 3: Message
			createCategoryPlugin({ '@typescript-eslint/*': 2 }),
		]
		: [],
	rules: await defineRules({
		'@typescript-eslint/consistent-type-imports': true,
		'@typescript-eslint/no-unnecessary-type-assertion': true,
	}),
});
```