### PR TITLE
fix(cli): `--filter` files enhancement

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -112,6 +112,8 @@ class Project {
 				clack.log.warn(`${label} ${path.relative(process.cwd(), this.tsconfig)} ${gray('(No files left after filter)')}`);
 				return this;
 			}
+		} else {
+			this.fileNames = this.rawFileNames;
 		}
 
 		const filteredLengthDiff = this.rawFileNames.length - this.fileNames.length;


### PR DESCRIPTION
- supports dot files for glob pattern
- pass raw file names instead of filtered file names to ts lang service when using `--filter`