### PR TITLE
chore: replace `glob` with `fs.globSync`

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -3,7 +3,6 @@ import path = require('path');
 import core = require('@tsslint/core');
 import cache = require('./lib/cache.js');
 import worker = require('./lib/worker.js');
-import glob = require('glob');
 import fs = require('fs');
 import os = require('os');
 import minimatch = require('minimatch');
@@ -208,7 +207,7 @@ class Project {
 			process.exit(1);
 		}
 
-		const tsconfigOptions = glob.sync('**/{tsconfig.json,tsconfig.*.json,jsconfig.json}');
+		const tsconfigOptions = fs.globSync('**/{tsconfig.json,tsconfig.*.json,jsconfig.json}');
 
 		let options = await Promise.all(
 			tsconfigOptions.map(async tsconfigOption => {
@@ -305,7 +304,7 @@ class Project {
 				}
 				foundArg = true;
 				const searchGlob = process.argv[i];
-				const tsconfigs = glob.sync(searchGlob);
+				const tsconfigs = fs.globSync(searchGlob);
 				if (!tsconfigs.length) {
 					clack.log.error(red(`No projects found for ${projectFlag} ${searchGlob}.`));
 					process.exit(1);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,6 @@
 		"@volar/language-core": "~2.4.0",
 		"@volar/language-hub": "0.0.1",
 		"@volar/typescript": "~2.4.0",
-		"glob": "^10.4.1",
 		"json5": "^2.2.3",
 		"minimatch": "^10.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,6 @@ importers:
       '@volar/typescript':
         specifier: ~2.4.0
         version: 2.4.23
-      glob:
-        specifier: ^10.4.1
-        version: 10.4.5
       json5:
         specifier: ^2.2.3
         version: 2.2.3


### PR DESCRIPTION
`@tsslint/cli` has 46 dependencies, 26 of which (more than half) come from the `glob` package. I'd like to reduce the dependency footprint of tsslint.

https://npmgraph.js.org/?q=@tsslint/cli#select=exact%3Aglob%4010.4.5

<img width="1919" height="917" alt="image" src="https://github.com/user-attachments/assets/1f8aa379-df01-4618-8dcb-b9b4be148e95" />


---

`fs.globSync` also [uses `minimatch` under the hood](https://github.com/nodejs/node/blob/daf0a44669992ea2dff7f4a5b14e6f9088ce4399/lib/internal/fs/glob.js#L43-L47), so it supports the same pattern syntax as `glob`.

There is no "engines" field in tsslint's package.json, so it's unclear which Node.js versions it is intended to support.
`fs.globSync` was added in Node.js v22.0.0 ([docs](https://nodejs.org/api/fs.html#fsglobsyncpattern-options)). Node.js v20.x will reach EOL on 2026-04-30, and active LTS for v22.x began a year ago. If you believe that tsslint should continue to support Node.js v20.x, feel free to close this PR (or wait until v20.x reaches EOL).
