### PR TITLE
cli/compat-eslint: --debug-estree source attribution

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -378,7 +378,13 @@ const formatHost: ts.FormatDiagnosticsHost = {
 		// on the CLI's neighbour copy — different module instances,
 		// different counters. globalThis closes that gap.
 		const COUNTS_KEY = Symbol.for('@tsslint/compat-eslint:node-type-counts');
+		const SOURCE_COUNTS_KEY = Symbol.for('@tsslint/compat-eslint:node-type-source-counts');
 		const counts = (globalThis as any)[COUNTS_KEY] as Map<string, number> | undefined;
+		// Source attribution: each (type, source) pair counted separately.
+		// Source enum: leaf-direct (visitor / scope-manager called materialise),
+		// leaf-resolve (resolveParent walked into this kind), child (top-down
+		// slot getter or wrapper construction), root (parent === null).
+		const sourceCounts = (globalThis as any)[SOURCE_COUNTS_KEY] as Map<string, number> | undefined;
 		const sorted = counts
 			? [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
 			: [];
@@ -388,11 +394,38 @@ const formatHost: ts.FormatDiagnosticsHost = {
 			colors.cyan('estree node types')
 				+ colors.gray(` (${sorted.length} kinds, ${total.toLocaleString()} nodes)`),
 		);
+		const SOURCES = ['leaf-direct', 'leaf-resolve', 'child', 'root'] as const;
+		const sourceWidths = SOURCES.map(s => s.length);
 		for (const [name, n] of sorted) {
-			renderer.info('  ' + name.padEnd(widthName) + '  ' + colors.gray(n.toLocaleString()));
+			let line = '  ' + name.padEnd(widthName) + '  ' + colors.gray(n.toLocaleString().padStart(8));
+			if (sourceCounts) {
+				const parts: string[] = [];
+				for (let i = 0; i < SOURCES.length; i++) {
+					const s = SOURCES[i];
+					const c = sourceCounts.get(name + '|' + s) ?? 0;
+					if (c > 0) parts.push(`${s}=${c.toLocaleString()}`);
+					sourceWidths[i] = Math.max(sourceWidths[i], s.length);
+				}
+				if (parts.length) line += colors.gray('  [' + parts.join(', ') + ']');
+			}
+			renderer.info(line);
 		}
 		if (!sorted.length) {
 			renderer.info(colors.gray('  (no nodes converted — no @tsslint/compat-eslint rules ran)'));
+		}
+		else if (sourceCounts) {
+			// Roll-up: total per source across all kinds.
+			const rollup = new Map<string, number>();
+			for (const [k, n] of sourceCounts) {
+				const src = k.slice(k.lastIndexOf('|') + 1);
+				rollup.set(src, (rollup.get(src) ?? 0) + n);
+			}
+			const rollupParts: string[] = [];
+			for (const s of SOURCES) {
+				const n = rollup.get(s) ?? 0;
+				if (n > 0) rollupParts.push(`${s}=${n.toLocaleString()}`);
+			}
+			renderer.info(colors.gray('  total by source: ' + rollupParts.join(', ')));
 		}
 	}
 

--- a/packages/compat-eslint/lib/lazy-estree.ts
+++ b/packages/compat-eslint/lib/lazy-estree.ts
@@ -75,16 +75,47 @@ const SK = ts.SyntaxKind;
 // `this.type` synchronously here would observe `undefined`.
 const DEBUG_ESTREE = process.env.TSSLINT_DEBUG_ESTREE === '1';
 const COUNTS_KEY = Symbol.for('@tsslint/compat-eslint:node-type-counts');
-type GlobalCountsHolder = { [k in typeof COUNTS_KEY]?: Map<string, number> };
+const SOURCE_COUNTS_KEY = Symbol.for('@tsslint/compat-eslint:node-type-source-counts');
+// Source attribution (DEBUG_ESTREE only): which code path created this node.
+//   - 'leaf-direct'  : `materialize(tsNode, ctx)` from outside (visitor /
+//                      scope-manager) with `parent: undefined`. The rule
+//                      directly targeted this node.
+//   - 'leaf-resolve' : `materialize` invoked via `resolveParent` while
+//                      walking a parent chain. Indicates a rule reading
+//                      `.parent` deep enough to walk past this kind.
+//   - 'child'        : top-down construction with a real LazyNode parent
+//                      — slot getter (`convertChild(child, this)`) or
+//                      wrapper construction (ChainExpression, …).
+//   - 'root'         : `parent === null`. Only ProgramNode + the
+//                      GenericTSNode fallback when the chain exhausts.
+type NodeSource = 'leaf-direct' | 'leaf-resolve' | 'child' | 'root';
+type GlobalCountsHolder = {
+	[k in typeof COUNTS_KEY]?: Map<string, number>;
+} & {
+	[k in typeof SOURCE_COUNTS_KEY]?: Map<string, number>;
+};
 const _global = globalThis as unknown as GlobalCountsHolder;
 const nodeTypeCounts: Map<string, number> = _global[COUNTS_KEY] ??= new Map();
+// Keyed `${type}|${source}` so the CLI can split the per-kind total by
+// origin without knowing the source enum.
+const nodeTypeSourceCounts: Map<string, number> = _global[SOURCE_COUNTS_KEY] ??= new Map();
+
+// Set inside `resolveParent` while it walks the chain. The constructor
+// reads it to pick `leaf-resolve` over `leaf-direct` for any
+// materialisation that happens during a parent walk-up.
+let resolvingParent = false;
 
 export function getNodeTypeCounts(): ReadonlyMap<string, number> {
 	return nodeTypeCounts;
 }
 
+export function getNodeTypeSourceCounts(): ReadonlyMap<string, number> {
+	return nodeTypeSourceCounts;
+}
+
 export function resetNodeTypeCounts(): void {
 	nodeTypeCounts.clear();
+	nodeTypeSourceCounts.clear();
 }
 
 export interface LazyAstMaps {
@@ -417,9 +448,20 @@ abstract class LazyNode {
 			// `this.type` is set by the subclass's `readonly type = '...'`
 			// field initialiser, which runs AFTER super() returns. Defer to
 			// the next microtask so the read sees the final value.
+			//
+			// Capture `source` synchronously — by the microtask, the
+			// `parent === undefined` / `resolvingParent` state has moved on.
+			const source: NodeSource =
+				parent === null
+					? 'root'
+					: parent === undefined
+					? (resolvingParent ? 'leaf-resolve' : 'leaf-direct')
+					: 'child';
 			queueMicrotask(() => {
 				const t = (this as unknown as { type: string }).type;
 				nodeTypeCounts.set(t, (nodeTypeCounts.get(t) ?? 0) + 1);
+				const key = t + '|' + source;
+				nodeTypeSourceCounts.set(key, (nodeTypeSourceCounts.get(key) ?? 0) + 1);
 			});
 		}
 	}
@@ -1300,6 +1342,19 @@ export function materialize(tsNode: ts.Node, ctx: ConvertContext): LazyNode {
 // the SourceFile itself (whose ESTree counterpart, ProgramShape, is
 // pre-registered with parent=null by `convertLazy`).
 function resolveParent(tsNode: ts.Node, ctx: ConvertContext): LazyNode | null {
+	// DEBUG_ESTREE attribution: any LazyNode constructed during the walk
+	// below should be tagged 'leaf-resolve' rather than 'leaf-direct'.
+	const prevResolving = resolvingParent;
+	resolvingParent = true;
+	try {
+		return resolveParentInner(tsNode, ctx);
+	}
+	finally {
+		resolvingParent = prevResolving;
+	}
+}
+
+function resolveParentInner(tsNode: ts.Node, ctx: ConvertContext): LazyNode | null {
 	let walker: ts.Node | undefined = tsNode.parent;
 	while (walker) {
 		if (shouldSkipAsParent(walker)) {

--- a/packages/compat-eslint/lib/lazy-estree.ts
+++ b/packages/compat-eslint/lib/lazy-estree.ts
@@ -89,11 +89,13 @@ const SOURCE_COUNTS_KEY = Symbol.for('@tsslint/compat-eslint:node-type-source-co
 //   - 'root'         : `parent === null`. Only ProgramNode + the
 //                      GenericTSNode fallback when the chain exhausts.
 type NodeSource = 'leaf-direct' | 'leaf-resolve' | 'child' | 'root';
-type GlobalCountsHolder = {
-	[k in typeof COUNTS_KEY]?: Map<string, number>;
-} & {
-	[k in typeof SOURCE_COUNTS_KEY]?: Map<string, number>;
-};
+type GlobalCountsHolder =
+	& {
+		[k in typeof COUNTS_KEY]?: Map<string, number>;
+	}
+	& {
+		[k in typeof SOURCE_COUNTS_KEY]?: Map<string, number>;
+	};
 const _global = globalThis as unknown as GlobalCountsHolder;
 const nodeTypeCounts: Map<string, number> = _global[COUNTS_KEY] ??= new Map();
 // Keyed `${type}|${source}` so the CLI can split the per-kind total by
@@ -451,12 +453,11 @@ abstract class LazyNode {
 			//
 			// Capture `source` synchronously — by the microtask, the
 			// `parent === undefined` / `resolvingParent` state has moved on.
-			const source: NodeSource =
-				parent === null
-					? 'root'
-					: parent === undefined
-					? (resolvingParent ? 'leaf-resolve' : 'leaf-direct')
-					: 'child';
+			const source: NodeSource = parent === null
+				? 'root'
+				: parent === undefined
+				? (resolvingParent ? 'leaf-resolve' : 'leaf-direct')
+				: 'child';
 			queueMicrotask(() => {
 				const t = (this as unknown as { type: string }).type;
 				nodeTypeCounts.set(t, (nodeTypeCounts.get(t) ?? 0) + 1);


### PR DESCRIPTION
## Summary

`--debug-estree` already prints a per-\`type\` count of materialised ESTree nodes. Useful for spotting hot kinds, less useful for asking *why* they're hot — visitor bitmap hit, slot getter read, or parent-chain walk?

This PR tags each construction with one of four sources:

| Source | When |
|---|---|
| \`leaf-direct\` | \`materialize(tsNode, ctx)\` from outside (visitor / scope-manager) with \`parent: undefined\`. Rule directly targeted this node. |
| \`leaf-resolve\` | \`materialize\` invoked via \`resolveParent\` walking a parent chain. Rule read \`.parent\` deep enough to hit this kind. |
| \`child\` | Top-down construction with a real LazyNode parent — slot getter (\`convertChild(child, this)\`) or wrapper construction. |
| \`root\` | \`parent === null\`. ProgramNode + the GenericTSNode fallback. |

Counted via a parallel \`nodeTypeSourceCounts\` map on \`globalThis\` (\`Symbol.for('@tsslint/compat-eslint:node-type-source-counts')\`) — same cross-package strategy as the existing per-type counter.

Cost when off: still one boolean check per construction. Cost when on: one extra \`.set()\` per node in the deferred microtask.

## Sample (Dify, react-x/no-leaked-conditional-rendering)

\`\`\`
estree node types (48 kinds, 138,046 nodes)
  JSXExpressionContainer    27,113  [leaf-direct=27,113]
  Identifier                26,982  [leaf-direct=1, child=26,981]
  JSXAttribute              16,552  [child=16,552]
  JSXElement                10,370  [leaf-resolve=6,934, child=3,436]
  CallExpression             9,891  [leaf-resolve=658, child=9,233]
  ArrowFunctionExpression    7,421  [leaf-direct=4,092, leaf-resolve=2,071, child=1,258]
  ...
  total by source: leaf-direct=37,517, leaf-resolve=16,243, child=80,622, root=3,664
\`\`\`

Confirms the post-lazy-parent state: no \"phantom\" allocations remain. JSXExpressionContainer's 27k are visitor-bitmap hits (the rule's actual scan target); JSXElement's 6.9k \`leaf-resolve\` are parent walks the rule actively needs; the 80k \`child\` total is genuine slot reads driven by the rule iterating LogicalExpression operands. The remaining ~138k nodes are what the rule fundamentally needs — the architecturally-removable waste is gone.

## Test plan

- [x] All compat-eslint tests pass (\`lazy-estree\`, \`predicate-coverage\` 152/152, \`scope-compat\` 24/24, \`selector-analysis\`, \`ts-ast-scan\`, \`compat-pipeline\`, \`jsx-react-x\` PARITY ✓)
- [x] Dify cold lint (\`--debug-estree --force\`) runs and prints the breakdown above