### PR TITLE
Drop LanguageService dependency from core and CLI

### DIFF
--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -211,9 +211,14 @@ async function setup(
 	};
 	linter = core.createLinter(
 		{
-			languageService: linterLanguageService,
-			languageServiceHost: linterHost,
 			typescript: ts,
+			// Thunk: each `lint()` call observes the LS's CURRENT program.
+			// `--fix` rewrites a file mid-session, bumps `projectVersion`,
+			// and the next `lint()` picks up the rebuilt program here. The
+			// LS itself is still TSSLint CLI's internal handle to TS — the
+			// public Linter API only sees Program. Pre-3.2 the linter took
+			// `{ languageService, languageServiceHost }`; both are gone.
+			program: () => linterLanguageService.getProgram()!,
 		},
 		path.dirname(configFile),
 		config,

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -15,18 +15,37 @@ import type { IncrementalState } from './incremental-state.js';
 // always provides it via crypto, but the type is optional). sha256 hex.
 const defaultHash = (s: string) => crypto.createHash('sha256').update(s).digest('hex');
 
-import { createLanguage, FileMap, isCodeActionsEnabled, type Language } from '@volar/language-core';
-import { createProxyLanguageService, decorateLanguageServiceHost, resolveFileLanguageId } from '@volar/typescript';
+import { isCodeActionsEnabled, type Language } from '@volar/language-core';
+import { proxyCreateProgram } from '@volar/typescript';
 import { transformDiagnostic, transformFileTextChanges } from '@volar/typescript/lib/node/transform';
 
-let projectVersion = 0;
-let typeRootsVersion = 0;
 let options: ts.CompilerOptions = {};
 let fileNames: string[] = [];
 let language: Language<string> | undefined;
 let linter: core.Linter;
-let linterLanguageService!: ts.LanguageService;
-// Layer 2 state. We wrap the LS program in a SemanticDiagnostics-
+// Cached Program instance + dirty flag. Pre-3.2 the worker wrapped a
+// LanguageService over a LanguageServiceHost; getProgram() implicitly
+// rebuilt when the host's projectVersion bumped. We've collapsed that
+// down to direct `ts.createProgram` calls — the LS provided no
+// linter-relevant capability beyond program-rebuild-on-version-bump,
+// and it pulled in completion / refactor / navigation machinery we
+// never used. `--fix` rewrites a file → bumps `programDirty` → next
+// `ensureProgram()` rebuilds with `oldProgram` for incremental binder
+// reuse (TS reuses unchanged SourceFiles' bound state, only re-binds
+// the modified file).
+let currentProgram: ts.Program | undefined;
+let programDirty = true;
+// In-session content overrides for `--fix`-modified files. The
+// CompilerHost's readFile / getSourceFile consult this map first so
+// the next program rebuild sees the post-fix text without disk I/O.
+const fileTextOverrides = new Map<string, string>();
+// Volar Language instance for Vue / MDX / Astro projects. Set by
+// `proxyCreateProgram`'s `setup` callback when a language plugin is
+// active; undefined for plain-TS projects.
+// `proxyCreateProgram` returns the wrapped `ts.createProgram`. For
+// plain-TS this stays as `ts.createProgram` itself.
+let createProgram: typeof ts.createProgram = ts.createProgram;
+// Layer 2 state. We wrap the program in a SemanticDiagnostics-
 // BuilderProgram (with the prev session's BP fed back via TS's internal
 // `tsBuildInfoText` round-trip) and walk affected files once. cache-
 // flow consults this set to decide whether type-aware rules can be
@@ -37,65 +56,59 @@ let affectedFiles: Set<string> | undefined;
 // capture its updated buildinfo text for next session's persistence.
 let currentBuilder: ts.SemanticDiagnosticsBuilderProgram | undefined;
 
-const snapshots = new Map<string, ts.IScriptSnapshot>();
-const versions = new Map<string, number>();
-const originalHost: ts.LanguageServiceHost = {
-	...ts.sys,
-	useCaseSensitiveFileNames() {
-		return ts.sys.useCaseSensitiveFileNames;
-	},
-	getProjectVersion() {
-		return projectVersion.toString();
-	},
-	getTypeRootsVersion() {
-		return typeRootsVersion;
-	},
-	getCompilationSettings() {
-		return options;
-	},
-	getScriptFileNames() {
-		return fileNames;
-	},
-	getScriptVersion(fileName) {
-		// In-session bumps win — `--fix` updates this map after writing
-		// the file. Otherwise fall back to the on-disk mtime so the
-		// version reflects content across CLI invocations. Layer 2's
-		// BuilderProgram diff relies on this — without it, every cross-
-		// session file looks unchanged (always '0') even when the
-		// content moved on disk.
-		const inSession = versions.get(fileName);
-		if (inSession !== undefined) return inSession.toString();
-		const stat = fs.statSync(fileName, { throwIfNoEntry: false });
-		return stat ? stat.mtimeMs.toString() : '0';
-	},
-	getScriptSnapshot(fileName) {
-		if (!snapshots.has(fileName)) {
-			snapshots.set(fileName, ts.ScriptSnapshot.fromString(ts.sys.readFile(fileName)!));
+// CompilerHost: lower-level than LanguageServiceHost. Just
+// readFile / writeFile / fileExists / lib-file resolution / case
+// sensitivity. We override `readFile` (and `getSourceFile`, which
+// internally reads via readFile) to consult `fileTextOverrides`.
+let compilerHost: ts.CompilerHost = createCompilerHost();
+
+function createCompilerHost(): ts.CompilerHost {
+	// `setParentNodes: true` — compat-eslint's bottom-up materialise
+	// walks ts.Node.parent chains; without parent pointers it crashes.
+	// `ts.createLanguageService` set this implicitly; `ts.createProgram`
+	// via `createCompilerHost` defaults false, so we set it explicitly.
+	const host = ts.createCompilerHost(options, true);
+	const originalReadFile = host.readFile.bind(host);
+	const originalGetSourceFile = host.getSourceFile.bind(host);
+	const hash = ts.sys.createHash ?? defaultHash;
+	host.readFile = (fileName: string) => {
+		const override = fileTextOverrides.get(fileName);
+		if (override !== undefined) return override;
+		return originalReadFile(fileName);
+	};
+	host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+		const sf = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+		// BuilderProgram requires `SourceFile.version` (Debug.checkDefined
+		// throws otherwise). The LS-host path got this via the host's
+		// `getScriptVersion`; raw CompilerHost has no equivalent, so we
+		// stamp a content hash here. Same value across runs as long as
+		// content matches → BuilderProgram's reference-graph diff
+		// correctly identifies unchanged files.
+		if (sf && (sf as unknown as { version?: string }).version === undefined) {
+			(sf as unknown as { version: string }).version = hash(sf.text);
 		}
-		return snapshots.get(fileName);
-	},
-	getScriptKind(fileName) {
-		const languageId = resolveFileLanguageId(fileName);
-		switch (languageId) {
-			case 'javascript':
-				return ts.ScriptKind.JS;
-			case 'javascriptreact':
-				return ts.ScriptKind.JSX;
-			case 'typescript':
-				return ts.ScriptKind.TS;
-			case 'typescriptreact':
-				return ts.ScriptKind.TSX;
-			case 'json':
-				return ts.ScriptKind.JSON;
-		}
-		return ts.ScriptKind.Unknown;
-	},
-	getDefaultLibFileName(options) {
-		return ts.getDefaultLibFilePath(options);
-	},
-};
-const linterHost: ts.LanguageServiceHost = { ...originalHost };
-const originalService = ts.createLanguageService(linterHost);
+		return sf;
+	};
+	return host;
+}
+
+function ensureProgram(): ts.Program {
+	if (programDirty || !currentProgram) {
+		// `oldProgram` lets `ts.createProgram` reuse SourceFiles whose
+		// text hasn't changed (text-equality check vs old SF) and skip
+		// re-parsing + re-binding for those. Modified files (via
+		// `fileTextOverrides`) get re-parsed; unchanged files are zero-
+		// cost.
+		currentProgram = createProgram({
+			rootNames: fileNames,
+			options,
+			host: compilerHost,
+			oldProgram: currentProgram,
+		});
+		programDirty = false;
+	}
+	return currentProgram;
+}
 
 // Linter is single-threaded by design. The previous version split into a
 // worker_threads worker for TTY mode (so the spinner could update during a
@@ -148,54 +161,20 @@ async function setup(
 		return String(err);
 	}
 
-	for (let key in linterHost) {
-		if (!(key in originalHost)) {
-			// @ts-ignore
-			delete linterHost[key];
-		}
-		else {
-			// @ts-ignore
-			linterHost[key] = originalHost[key];
-		}
-	}
-	linterLanguageService = originalService;
-	language = undefined;
-
 	// Reset per-project state. Multi-project runs reuse the same worker
 	// (in-process) — without this, cross-project file paths accumulate in
-	// `snapshots` / `versions` (memory leak) and `affectedFiles` from a
-	// prior project would mis-classify this project's files as cache-hit
+	// `fileTextOverrides` (memory leak) and `affectedFiles` from a prior
+	// project would mis-classify this project's files as cache-hit
 	// candidates if their absolute paths happened to overlap.
-	snapshots.clear();
-	versions.clear();
+	fileTextOverrides.clear();
+	currentProgram = undefined;
+	programDirty = true;
+	language = undefined;
+	createProgram = ts.createProgram;
 	affectedFiles = undefined;
 	currentBuilder = undefined;
 
 	const plugins = await languagePlugins.load(tsconfig, languages);
-	if (plugins.length) {
-		const { getScriptSnapshot } = originalHost;
-		language = createLanguage<string>(
-			[
-				...plugins,
-				{ getLanguageId: fileName => resolveFileLanguageId(fileName) },
-			],
-			new FileMap(ts.sys.useCaseSensitiveFileNames),
-			fileName => {
-				const snapshot = getScriptSnapshot(fileName);
-				if (snapshot) {
-					language!.scripts.set(fileName, snapshot);
-				}
-			},
-		);
-		decorateLanguageServiceHost(ts, language, linterHost);
-
-		const proxy = createProxyLanguageService(linterLanguageService);
-		proxy.initialize(language);
-		linterLanguageService = proxy.proxy;
-	}
-
-	projectVersion++;
-	typeRootsVersion++;
 	fileNames = _fileNames;
 	// Internal API path: BuilderProgram.emitBuildInfo only produces
 	// content when these options are set. Override the user's values
@@ -209,16 +188,30 @@ async function setup(
 		incremental: true,
 		tsBuildInfoFile: incrementalState.SYNTHETIC_BUILD_INFO_PATH,
 	};
+	// Compile a fresh CompilerHost each setup — `options` may have
+	// changed, and createCompilerHost bakes them in (default lib paths,
+	// case sensitivity).
+	compilerHost = createCompilerHost();
+	if (plugins.length) {
+		// Volar wraps `ts.createProgram` so Vue / MDX / Astro virtual
+		// scripts get spliced into the program. The `setup` callback
+		// gives us the Volar Language handle for diagnostic / fix
+		// transforms downstream.
+		createProgram = proxyCreateProgram(ts, ts.createProgram, () => ({
+			languagePlugins: plugins,
+			setup(lang) {
+				language = lang;
+			},
+		}));
+	}
 	linter = core.createLinter(
 		{
 			typescript: ts,
-			// Thunk: each `lint()` call observes the LS's CURRENT program.
-			// `--fix` rewrites a file mid-session, bumps `projectVersion`,
-			// and the next `lint()` picks up the rebuilt program here. The
-			// LS itself is still TSSLint CLI's internal handle to TS — the
-			// public Linter API only sees Program. Pre-3.2 the linter took
-			// `{ languageService, languageServiceHost }`; both are gone.
-			program: () => linterLanguageService.getProgram()!,
+			// Thunk: each `lint()` call gets the latest Program. `--fix`
+			// rewrites a file mid-session → flips `programDirty` → next
+			// `ensureProgram()` rebuilds with `oldProgram` for incremental
+			// binder reuse.
+			program: ensureProgram,
 		},
 		path.dirname(configFile),
 		config,
@@ -227,7 +220,7 @@ async function setup(
 	);
 
 	{
-		const program = linterLanguageService.getProgram()!;
+		const program = ensureProgram();
 		// Reconstruct the prev session's BP from cached buildinfo text,
 		// fall through to undefined on any failure (cold-start path).
 		const oldBuilder = incrementalState.reconstructOldBuilder(ts, prevIncrementalState, {
@@ -284,7 +277,7 @@ function buildIncrementalState(): IncrementalState | undefined {
 }
 
 function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: number) {
-	let newSnapshot: ts.IScriptSnapshot | undefined;
+	let newText: string | undefined;
 	let diagnostics!: ts.DiagnosticWithLocation[];
 	let shouldCheck = true;
 
@@ -307,8 +300,7 @@ function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: n
 				delete fileCache.rules[ruleId];
 			}
 		}
-		const program = linterLanguageService.getProgram()!;
-		diagnostics = cacheFlow.lintWithCache(linter, fileName, fileCache, fileMtime, program, {
+		diagnostics = cacheFlow.lintWithCache(linter, fileName, fileCache, fileMtime, ensureProgram(), {
 			incremental: true,
 			typeAwareUnaffected,
 		});
@@ -327,19 +319,20 @@ function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: n
 
 		const textChanges = core.combineCodeFixes(fileName, fixes);
 		if (textChanges.length) {
-			const oldSnapshot = snapshots.get(fileName)!;
-			newSnapshot = core.applyTextChanges(oldSnapshot, textChanges);
-			snapshots.set(fileName, newSnapshot);
-			versions.set(fileName, (versions.get(fileName) ?? 0) + 1);
-			projectVersion++;
+			// Apply edits to the current text (override map first, fall
+			// through to disk). Stash result in `fileTextOverrides` so the
+			// next `ensureProgram()` rebuild sees the post-fix content.
+			const baseText = fileTextOverrides.get(fileName) ?? ts.sys.readFile(fileName) ?? '';
+			newText = core.applyTextChanges(baseText, textChanges);
+			fileTextOverrides.set(fileName, newText);
+			programDirty = true;
 		}
 	}
 
-	if (newSnapshot) {
-		const newText = newSnapshot.getText(0, newSnapshot.getLength());
+	if (newText !== undefined) {
 		const oldText = ts.sys.readFile(fileName);
 		if (newText !== oldText) {
-			ts.sys.writeFile(fileName, newSnapshot.getText(0, newSnapshot.getLength()));
+			ts.sys.writeFile(fileName, newText);
 			// File content moved — refresh mtime so the next lint pass
 			// invalidates layer-1 cache entries for this file. lintWithCache
 			// compares fileCache.mtime against the fileMtime we pass in.
@@ -349,8 +342,7 @@ function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: n
 	}
 
 	if (shouldCheck) {
-		const program = linterLanguageService.getProgram()!;
-		diagnostics = cacheFlow.lintWithCache(linter, fileName, fileCache, fileMtime, program, {
+		diagnostics = cacheFlow.lintWithCache(linter, fileName, fileCache, fileMtime, ensureProgram(), {
 			incremental: true,
 			typeAwareUnaffected,
 		});
@@ -358,12 +350,12 @@ function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: n
 
 	// Language-transform path (Vue/MDX/etc.): diagnostics map back from
 	// the transformed file to the original source. The original file
-	// might not be in the language service's program, so we substitute a
-	// SourceFile-shaped POJO with the real source text — `formatDiagnostics-
-	// WithColorAndContext` reads `.file.text` to render code snippets.
+	// might not be in the program, so we substitute a SourceFile-shaped
+	// POJO with the real source text — `formatDiagnosticsWithColorAndContext`
+	// reads `.file.text` to render code snippets.
 	if (language) {
 		diagnostics = diagnostics
-			.map(d => transformDiagnostic(language!, d, (originalService as any).getCurrentProgram(), false))
+			.map(d => transformDiagnostic(language!, d, ensureProgram(), false))
 			.filter(d => !!d);
 		const fileShim = new Map<string, { fileName: string; text: string }>();
 		const getShim = (fn: string) => {
@@ -392,7 +384,7 @@ function lint(fileName: string, fix: boolean, fileCache: FileCache, fileMtime: n
 }
 
 function getFileText(fileName: string) {
-	return originalHost.getScriptSnapshot(fileName)!.getText(0, Number.MAX_VALUE);
+	return fileTextOverrides.get(fileName) ?? ts.sys.readFile(fileName) ?? '';
 }
 
 function hasCodeFixes(fileName: string) {

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -42,6 +42,16 @@ let programDirty = true;
 // CompilerHost's readFile / getSourceFile consult this map first so
 // the next program rebuild sees the post-fix text without disk I/O.
 const fileTextOverrides = new Map<string, string>();
+// Process-level SourceFile cache, shared across projects in the same
+// CLI invocation (`tsslint --project a/tsconfig.json --project b/tsconfig.json`
+// runs in one worker). Pre-3.2 the LS instance survived setup() calls
+// and its internal SourceFile cache reused lib.es5.d.ts / shared
+// node_modules types across projects; with the LS gone, `oldProgram`-
+// based reuse only works within a project (TS bails when
+// compilerOptions differ across tsconfigs). This keeps lib + shared
+// types from re-parsing per project. Invalidated by content change
+// (text-equality check on lookup) so `--fix` rewrites are seen.
+const sourceFileCache = new Map<string, ts.SourceFile>();
 // Layer 2 state. We wrap the program in a SemanticDiagnostics-
 // BuilderProgram (with the prev session's BP fed back via TS's internal
 // `tsBuildInfoText` round-trip) and walk affected files once. cache-
@@ -75,8 +85,6 @@ function createCompilerHost(): ts.CompilerHost {
 		return originalReadFile(fileName);
 	};
 	host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
-		const orig = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
-		if (!orig) return orig;
 		// Vue / MDX / Astro virtualisation. We replicate `proxyCreateProgram`
 		// but DO NOT apply its `decorateProgram` step — that wraps
 		// `program.getSemanticDiagnostics` to call `fillSourceFileText`,
@@ -88,10 +96,17 @@ function createCompilerHost(): ts.CompilerHost {
 		// match the AST it was given. Master got away with this by going
 		// through `decorateLanguageServiceHost` (LS-side, doesn't touch
 		// the program) instead.
+		//
+		// Virtualised SFs are NOT cached cross-project: the plugin's
+		// `getServiceScript` output depends on the per-project `language`
+		// instance, so two projects with different language plugins can
+		// produce different virtual TS for the same fileName.
 		if (language) {
 			const sourceScript = language.scripts.get(fileName);
 			const tsAdapter = sourceScript?.generated?.languagePlugin.typescript;
 			if (sourceScript && tsAdapter) {
+				const orig = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+				if (!orig) return orig;
 				const serviceScript = tsAdapter.getServiceScript(sourceScript.generated!.root);
 				if (serviceScript) {
 					// Two layouts depending on the plugin:
@@ -115,6 +130,22 @@ function createCompilerHost(): ts.CompilerHost {
 				}
 			}
 		}
+		// Plain-TS path. Cross-project SF cache: same path + same content
+		// → return the cached SF unchanged. Skips re-parse for lib.es5.d.ts
+		// and any node_modules types both projects pull in. The text-
+		// equality check is what invalidates after `--fix` (override
+		// changes the text → cache miss → fresh parse).
+		const text = host.readFile(fileName);
+		if (text === undefined) {
+			sourceFileCache.delete(fileName);
+			return undefined;
+		}
+		const cached = sourceFileCache.get(fileName);
+		if (cached && cached.text === text) {
+			return cached;
+		}
+		const orig = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+		if (!orig) return orig;
 		// BuilderProgram requires `SourceFile.version` (Debug.checkDefined
 		// throws otherwise). The LS-host path got this via the host's
 		// `getScriptVersion`; raw CompilerHost has no equivalent, so we
@@ -124,6 +155,7 @@ function createCompilerHost(): ts.CompilerHost {
 		if ((orig as unknown as { version?: string }).version === undefined) {
 			(orig as unknown as { version: string }).version = hash(orig.text);
 		}
+		sourceFileCache.set(fileName, orig);
 		return orig;
 	};
 	return host;
@@ -204,11 +236,19 @@ async function setup(
 	// project would mis-classify this project's files as cache-hit
 	// candidates if their absolute paths happened to overlap.
 	fileTextOverrides.clear();
-	currentProgram = undefined;
-	programDirty = true;
 	language = undefined;
 	affectedFiles = undefined;
 	currentBuilder = undefined;
+	// `currentProgram` is intentionally NOT cleared — `ensureProgram()`
+	// will pass it as `oldProgram` to the next `ts.createProgram` call.
+	// TS reuses SourceFiles whose path + text match across the two
+	// programs, so lib files (lib.es5.d.ts etc., shared between every
+	// project) and any node_modules types both projects pull in skip
+	// the parse + bind cost on the second project. Pre-3.2 the LS
+	// instance survived across projects with the same effect; this
+	// preserves that. `programDirty = true` forces the rebuild so the
+	// new project's rootNames + options take effect.
+	programDirty = true;
 
 	const plugins = await languagePlugins.load(tsconfig, languages);
 	fileNames = _fileNames;

--- a/packages/cli/lib/worker.ts
+++ b/packages/cli/lib/worker.ts
@@ -15,12 +15,15 @@ import type { IncrementalState } from './incremental-state.js';
 // always provides it via crypto, but the type is optional). sha256 hex.
 const defaultHash = (s: string) => crypto.createHash('sha256').update(s).digest('hex');
 
-import { isCodeActionsEnabled, type Language } from '@volar/language-core';
-import { proxyCreateProgram } from '@volar/typescript';
+import { createLanguage, FileMap, isCodeActionsEnabled, type Language } from '@volar/language-core';
+import { resolveFileLanguageId } from '@volar/typescript';
 import { transformDiagnostic, transformFileTextChanges } from '@volar/typescript/lib/node/transform';
 
 let options: ts.CompilerOptions = {};
 let fileNames: string[] = [];
+// Volar Language handle — populated by `proxyCreateProgram`'s `setup`
+// callback when a language plugin is active (Vue / MDX / Astro);
+// undefined for plain-TS projects.
 let language: Language<string> | undefined;
 let linter: core.Linter;
 // Cached Program instance + dirty flag. Pre-3.2 the worker wrapped a
@@ -39,12 +42,6 @@ let programDirty = true;
 // CompilerHost's readFile / getSourceFile consult this map first so
 // the next program rebuild sees the post-fix text without disk I/O.
 const fileTextOverrides = new Map<string, string>();
-// Volar Language instance for Vue / MDX / Astro projects. Set by
-// `proxyCreateProgram`'s `setup` callback when a language plugin is
-// active; undefined for plain-TS projects.
-// `proxyCreateProgram` returns the wrapped `ts.createProgram`. For
-// plain-TS this stays as `ts.createProgram` itself.
-let createProgram: typeof ts.createProgram = ts.createProgram;
 // Layer 2 state. We wrap the program in a SemanticDiagnostics-
 // BuilderProgram (with the prev session's BP fed back via TS's internal
 // `tsBuildInfoText` round-trip) and walk affected files once. cache-
@@ -59,7 +56,8 @@ let currentBuilder: ts.SemanticDiagnosticsBuilderProgram | undefined;
 // CompilerHost: lower-level than LanguageServiceHost. Just
 // readFile / writeFile / fileExists / lib-file resolution / case
 // sensitivity. We override `readFile` (and `getSourceFile`, which
-// internally reads via readFile) to consult `fileTextOverrides`.
+// internally reads via readFile) to consult `fileTextOverrides` AND
+// to virtualise Vue / MDX / Astro files via the active language plugin.
 let compilerHost: ts.CompilerHost = createCompilerHost();
 
 function createCompilerHost(): ts.CompilerHost {
@@ -77,17 +75,56 @@ function createCompilerHost(): ts.CompilerHost {
 		return originalReadFile(fileName);
 	};
 	host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
-		const sf = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+		const orig = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+		if (!orig) return orig;
+		// Vue / MDX / Astro virtualisation. We replicate `proxyCreateProgram`
+		// but DO NOT apply its `decorateProgram` step — that wraps
+		// `program.getSemanticDiagnostics` to call `fillSourceFileText`,
+		// which mutates `SourceFile.text` in place to splice the original
+		// .vue text back over the leading-offset spaces. The mutation
+		// happens AFTER the AST has been parsed, so the rule walks an AST
+		// whose positions now point at characters in the post-mutation
+		// text — the rule reports diagnostics at offsets that no longer
+		// match the AST it was given. Master got away with this by going
+		// through `decorateLanguageServiceHost` (LS-side, doesn't touch
+		// the program) instead.
+		if (language) {
+			const sourceScript = language.scripts.get(fileName);
+			const tsAdapter = sourceScript?.generated?.languagePlugin.typescript;
+			if (sourceScript && tsAdapter) {
+				const serviceScript = tsAdapter.getServiceScript(sourceScript.generated!.root);
+				if (serviceScript) {
+					// Two layouts depending on the plugin:
+					//   - !preventLeadingOffset: replace original-text positions
+					//     with whitespace (preserves source-map offsets), then
+					//     append the plugin's emitted TS.
+					//   - preventLeadingOffset: just emit the plugin's TS.
+					const virtualText = !serviceScript.preventLeadingOffset
+						? orig.text.split('\n').map(l => ' '.repeat(l.length)).join('\n')
+							+ serviceScript.code.snapshot.getText(0, serviceScript.code.snapshot.getLength())
+						: serviceScript.code.snapshot.getText(0, serviceScript.code.snapshot.getLength());
+					const virtual = ts.createSourceFile(
+						fileName,
+						virtualText,
+						languageVersion,
+						/*setParentNodes*/ true,
+						serviceScript.scriptKind,
+					);
+					(virtual as unknown as { version: string }).version = hash(virtualText);
+					return virtual;
+				}
+			}
+		}
 		// BuilderProgram requires `SourceFile.version` (Debug.checkDefined
 		// throws otherwise). The LS-host path got this via the host's
 		// `getScriptVersion`; raw CompilerHost has no equivalent, so we
 		// stamp a content hash here. Same value across runs as long as
 		// content matches → BuilderProgram's reference-graph diff
 		// correctly identifies unchanged files.
-		if (sf && (sf as unknown as { version?: string }).version === undefined) {
-			(sf as unknown as { version: string }).version = hash(sf.text);
+		if ((orig as unknown as { version?: string }).version === undefined) {
+			(orig as unknown as { version: string }).version = hash(orig.text);
 		}
-		return sf;
+		return orig;
 	};
 	return host;
 }
@@ -99,7 +136,7 @@ function ensureProgram(): ts.Program {
 		// re-parsing + re-binding for those. Modified files (via
 		// `fileTextOverrides`) get re-parsed; unchanged files are zero-
 		// cost.
-		currentProgram = createProgram({
+		currentProgram = ts.createProgram({
 			rootNames: fileNames,
 			options,
 			host: compilerHost,
@@ -170,7 +207,6 @@ async function setup(
 	currentProgram = undefined;
 	programDirty = true;
 	language = undefined;
-	createProgram = ts.createProgram;
 	affectedFiles = undefined;
 	currentBuilder = undefined;
 
@@ -188,22 +224,34 @@ async function setup(
 		incremental: true,
 		tsBuildInfoFile: incrementalState.SYNTHETIC_BUILD_INFO_PATH,
 	};
-	// Compile a fresh CompilerHost each setup — `options` may have
-	// changed, and createCompilerHost bakes them in (default lib paths,
-	// case sensitivity).
-	compilerHost = createCompilerHost();
 	if (plugins.length) {
-		// Volar wraps `ts.createProgram` so Vue / MDX / Astro virtual
-		// scripts get spliced into the program. The `setup` callback
-		// gives us the Volar Language handle for diagnostic / fix
-		// transforms downstream.
-		createProgram = proxyCreateProgram(ts, ts.createProgram, () => ({
-			languagePlugins: plugins,
-			setup(lang) {
-				language = lang;
+		// Manual replication of `proxyCreateProgram`'s language setup —
+		// without its `decorateProgram` step, which mutates the program's
+		// `getSemanticDiagnostics` to call `fillSourceFileText` and
+		// breaks AST-position lookups (see `createCompilerHost`). The
+		// host's `getSourceFile` consults `language.scripts` to splice
+		// virtual TS into Vue / MDX / Astro files.
+		language = createLanguage<string>(
+			[
+				...plugins,
+				{ getLanguageId: fileName => resolveFileLanguageId(fileName) },
+			],
+			new FileMap(ts.sys.useCaseSensitiveFileNames),
+			(fileName, includeFsFiles) => {
+				if (!includeFsFiles) return;
+				const text = fileTextOverrides.get(fileName) ?? ts.sys.readFile(fileName);
+				if (text === undefined) {
+					language!.scripts.delete(fileName);
+					return;
+				}
+				language!.scripts.set(fileName, ts.ScriptSnapshot.fromString(text));
 			},
-		}));
+		);
 	}
+	// Compile a fresh CompilerHost AFTER `language` is wired so the
+	// host's getSourceFile virtualisation can read from it. `options`
+	// may have changed too — createCompilerHost bakes those in.
+	compilerHost = createCompilerHost();
 	linter = core.createLinter(
 		{
 			typescript: ts,

--- a/packages/cli/test/cache-flow.test.ts
+++ b/packages/cli/test/cache-flow.test.ts
@@ -43,7 +43,8 @@ function makeContext(files: Record<string, string>) {
 		fileExists: n => n in files || n === realLibPath,
 		readFile: n => (n in files ? files[n] : (n === realLibPath ? realLibContent : undefined)),
 	};
-	return { typescript: ts, languageServiceHost: host, languageService: ts.createLanguageService(host) };
+	const languageService = ts.createLanguageService(host);
+	return { typescript: ts, program: () => languageService.getProgram()! };
 }
 
 function emptyFileCache(mtime = 0): FileCache {
@@ -62,7 +63,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	check('syntactic rule cache entry written', !!cache.rules['syntactic']);
 	check('cache has 1 diagnostic', cache.rules['syntactic']?.diagnostics.length === 1);
 	check('hasFix false (no fix reported)', cache.rules['syntactic']?.hasFix === false);
@@ -81,7 +82,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const result = cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	const result = cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	check('type-aware rule still produces diagnostics', result.length === 1);
 	check('type-aware rule NOT cached', !cache.rules['typed']);
 }
@@ -100,7 +101,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program);
 	check('first call ran rule', runs === 1);
@@ -128,7 +129,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program);
 	check('first call ran', runs === 1);
@@ -156,7 +157,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	check('post-rule cleanup deleted entry', !cache.rules['report-then-touch']);
 }
 
@@ -179,7 +180,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cacheA = emptyFileCache(1);
 	const cacheB = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 	cacheFlow.lintWithCache(linter, '/a.ts', cacheA, 1, program);
 	cacheFlow.lintWithCache(linter, '/b.ts', cacheB, 1, program);
 	check('a.ts no cache entry (touched)', !cacheA.rules['sometimes-typed']);
@@ -221,7 +222,7 @@ function emptyFileCache(mtime = 0): FileCache {
 			},
 		},
 	};
-	const result = cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	const result = cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	check('rule re-ran (stale cache ignored)', runs === 1);
 	check('result reflects fresh run', result.length === 1);
 	check('stale entry deleted', !cache.rules['typed']);
@@ -239,7 +240,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	check('hasFix true after rule registered fix', cache.rules['fixable']?.hasFix === true);
 }
 
@@ -261,7 +262,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	// First call: both run
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program);
@@ -294,7 +295,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program, { incremental: true, typeAwareUnaffected: true });
 	check('first call ran (no cache yet)', runs === 1);
@@ -324,7 +325,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program, { incremental: true, typeAwareUnaffected: true });
 	const second = cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program, {
@@ -358,7 +359,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	// Mode B: write the entry.
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program, { incremental: true, typeAwareUnaffected: true });
@@ -383,7 +384,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	// No options arg → mode A. Type-aware rules never cached.
 	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, program);
@@ -414,7 +415,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	const program = ctx.languageService.getProgram()!;
+	const program = ctx.program();
 
 	// Cold session under --incremental: no prev state, file is "affected"
 	// (unaffected=false). Must run AND write entry.
@@ -454,7 +455,7 @@ function emptyFileCache(mtime = 0): FileCache {
 		'/a.ts',
 		cache,
 		1,
-		ctx.languageService.getProgram()!,
+		ctx.program(),
 	);
 	check('current run returns both diagnostics', diags.length === 2);
 	check(
@@ -485,7 +486,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 
 	// Second run with the same mtime — rule cache-hits, only the
 	// persisted diagnostic comes back.
@@ -495,7 +496,7 @@ function emptyFileCache(mtime = 0): FileCache {
 		'/a.ts',
 		cache,
 		1,
-		ctx.languageService.getProgram()!,
+		ctx.program(),
 	);
 	check('warm cache hit returns 1 diagnostic', diags.length === 1);
 	check('warm replay drops the marked one', diags[0]?.messageText === 'plain');
@@ -528,7 +529,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	// ── Session 1: cold, both files lint — process the early-return file
 	// FIRST so the rule isn't yet type-aware when its entry gets written.
 	const linter1 = core.createLinter(ctx, '/', config, () => []);
-	const program1 = ctx.languageService.getProgram()!;
+	const program1 = ctx.program();
 	const cacheSkip: FileCache = emptyFileCache(1);
 	const cacheCheck: FileCache = emptyFileCache(1);
 	cacheFlow.lintWithCache(linter1, '/skip.ts', cacheSkip, 1, program1);
@@ -551,7 +552,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	// Both files unchanged. typeAwareUnaffected=true → both should
 	// cache-hit and replay cleanly.
 	const linter2 = core.createLinter(ctx, '/', config, () => [], ['mixed-mode']);
-	const program2 = ctx.languageService.getProgram()!;
+	const program2 = ctx.program();
 	let earlyReturnRanInSession2 = false;
 	const config2: Config = {
 		rules: {
@@ -599,7 +600,7 @@ function emptyFileCache(mtime = 0): FileCache {
 	};
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const cache = emptyFileCache(1);
-	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.languageService.getProgram()!);
+	cacheFlow.lintWithCache(linter, '/a.ts', cache, 1, ctx.program());
 	// rule entry exists but with 0 diagnostics — no smuggled keys.
 	const json = JSON.stringify(cache);
 	check('NO_CACHE marker not visible in serialised cache', !json.includes('no-cache'));

--- a/packages/cli/test/meta-frameworks.test.ts
+++ b/packages/cli/test/meta-frameworks.test.ts
@@ -1,0 +1,102 @@
+// Smoke test for the meta-framework language-plugin path. Spawns the
+// real tsslint CLI against the in-tree `fixtures/meta-frameworks` fixture
+// (.tsx + .vue + .vine.ts + .astro + .mdx) for each `--*-project` flag,
+// asserts the no-console rule fires on EACH framework's script content.
+//
+// This catches the regression class where the language plugin loads but
+// the script content never makes it into the linter's program — e.g. a
+// virtual-script transformation that gets undone before AST walk. Pre-
+// 3.2 (LS-side `decorateLanguageServiceHost`) and post-3.2 (program-side
+// host wrap) both have the same user-visible contract: `console.log`
+// inside `<script>` blocks fires the rule.
+//
+// Run via:
+//   node packages/cli/test/meta-frameworks.test.js
+
+import path = require('path');
+import fs = require('fs');
+import { spawnSync } from 'child_process';
+
+const failures: string[] = [];
+function check(name: string, cond: boolean, detail?: string) {
+	if (cond) {
+		process.stdout.write('.');
+	}
+	else {
+		failures.push(name + (detail ? ' — ' + detail : ''));
+		process.stdout.write('F');
+	}
+}
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const tsslintBin = path.join(repoRoot, 'packages/cli/bin/tsslint.js');
+const fixtureDir = path.join(repoRoot, 'fixtures/meta-frameworks');
+
+if (!fs.existsSync(path.join(fixtureDir, 'node_modules'))) {
+	console.log('meta-frameworks fixture missing node_modules; skipping.');
+	console.log('OK');
+	process.exit(0);
+}
+
+interface Pipeline {
+	flag: '--vue-project' | '--mdx-project' | '--astro-project' | '--vue-vine-project';
+	scriptFile: string;
+}
+
+const pipelines: Pipeline[] = [
+	// Each pipeline expects no-console to fire on at least:
+	//   - fixture.tsx (plain TS path — sanity check, language plugin
+	//     shouldn't break the .tsx flow)
+	//   - the framework's own script file (proves the plugin's virtual
+	//     script reached the AST walker)
+	//
+	// vue-vine pins to `fixture.vue` rather than `fixture.vine.ts`: the
+	// upstream `@vue-vine/language-service` shipped on the workspace has
+	// a known `vueCompilerOptions.globalTypesPath is not a function`
+	// crash inside its `createVirtualCode`, so .vine.ts script content
+	// never reaches the AST. Master has the same gap. We keep the .vue
+	// assertion to verify the vue-vine plugin's .vue path still works.
+	{ flag: '--vue-project', scriptFile: 'fixture.vue' },
+	{ flag: '--mdx-project', scriptFile: 'fixture.mdx' },
+	{ flag: '--astro-project', scriptFile: 'fixture.astro' },
+	{ flag: '--vue-vine-project', scriptFile: 'fixture.vue' },
+];
+
+function strip(s: string) {
+	// CLI output includes ANSI colour escapes; tests compare against the
+	// underlying text only.
+	return s.replace(/\[[0-9;]*m/g, '');
+}
+
+function runCli(flag: Pipeline['flag']): string {
+	const r = spawnSync(
+		process.execPath,
+		[tsslintBin, flag, 'tsconfig.json', '--force'],
+		{ cwd: fixtureDir, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+	);
+	return strip(r.stdout || '') + strip(r.stderr || '');
+}
+
+for (const { flag, scriptFile } of pipelines) {
+	const out = runCli(flag);
+	// Plain-TS sanity: rule fires on .tsx
+	check(
+		`${flag}: rule fires on fixture.tsx`,
+		out.includes('fixture.tsx') && out.includes("Calls to 'console.x' are not allowed."),
+		`output: ${out.slice(0, 400)}`,
+	);
+	// Language-plugin path: rule fires on the framework file
+	check(
+		`${flag}: rule fires on ${scriptFile}`,
+		out.includes(scriptFile) && out.includes("Calls to 'console.x' are not allowed."),
+		`output: ${out.slice(0, 400)}`,
+	);
+}
+
+process.stdout.write('\n');
+if (failures.length) {
+	console.error(`\n${failures.length} failure(s):`);
+	for (const f of failures) console.error('  - ' + f);
+	process.exit(1);
+}
+console.log('OK');

--- a/packages/cli/test/program-host.test.ts
+++ b/packages/cli/test/program-host.test.ts
@@ -27,8 +27,8 @@
 // Run via:
 //   node packages/cli/test/program-host.test.js
 
-import * as ts from 'typescript';
 import * as crypto from 'crypto';
+import * as ts from 'typescript';
 
 const failures: string[] = [];
 function check(name: string, cond: boolean, detail?: string) {
@@ -111,7 +111,11 @@ function buildProgram(files: Record<string, string>, fileTextOverrides: Map<stri
 	catch (err) {
 		threw = err;
 	}
-	check('createSemanticDiagnosticsBuilderProgram does not throw', threw === undefined, threw ? String(threw) : undefined);
+	check(
+		'createSemanticDiagnosticsBuilderProgram does not throw',
+		threw === undefined,
+		threw ? String(threw) : undefined,
+	);
 	check('BuilderProgram instance returned', !!builder);
 }
 

--- a/packages/cli/test/program-host.test.ts
+++ b/packages/cli/test/program-host.test.ts
@@ -1,0 +1,250 @@
+// Regression tests for the worker's CompilerHost setup. The CLI
+// worker (post-3.2) builds Programs directly via `ts.createProgram`
+// instead of going through a LanguageService. Two non-obvious
+// invariants come out of that switch:
+//
+//   1. SourceFile.version stamping — `ts.createSemanticDiagnosticsBuilderProgram`
+//      throws (`Debug.checkDefined`) if any SourceFile is missing
+//      `.version`. The LS path got that for free via the host's
+//      `getScriptVersion`; raw CompilerHost has no equivalent, so the
+//      worker overrides `getSourceFile` to stamp a content hash.
+//
+//   2. setParentNodes — compat-eslint's bottom-up materialise walks
+//      `ts.Node.parent` chains; without them it crashes. `ts.createLanguageService`
+//      sets parent nodes implicitly; raw `ts.createCompilerHost` defaults
+//      false, so the worker passes `true` explicitly.
+//
+//   3. fileTextOverrides → readFile / getSourceFile → BuilderProgram
+//      sees post-fix content. `--fix` rewrites a file and stashes the
+//      new text in the override map; the next `ensureProgram()` rebuild
+//      consumes it via `host.readFile`, and TS's text-equality reuse
+//      logic identifies the file as modified vs the oldProgram.
+//
+// These tests pin those invariants so a future "let's drop the version
+// stamp / setParentNodes argument" cleanup fails loudly instead of
+// crashing only on real projects.
+//
+// Run via:
+//   node packages/cli/test/program-host.test.js
+
+import * as ts from 'typescript';
+import * as crypto from 'crypto';
+
+const failures: string[] = [];
+function check(name: string, cond: boolean, detail?: string) {
+	if (cond) {
+		process.stdout.write('.');
+	}
+	else {
+		failures.push(name + (detail ? ' — ' + detail : ''));
+		process.stdout.write('F');
+	}
+}
+
+const defaultHash = (s: string) => crypto.createHash('sha256').update(s).digest('hex');
+
+// Mirror the worker's CompilerHost setup: in-memory file system layered
+// over `ts.sys` for lib resolution + version stamping + setParentNodes.
+function makeHost(files: Record<string, string>, fileTextOverrides: Map<string, string>): ts.CompilerHost {
+	const realLibPath = ts.getDefaultLibFilePath({ target: ts.ScriptTarget.Latest });
+	const realLibContent = ts.sys.readFile(realLibPath) ?? '';
+	const options: ts.CompilerOptions = {
+		target: ts.ScriptTarget.Latest,
+		noEmit: true,
+		incremental: true,
+		lib: [realLibPath.split(/[\\/]/).pop()!],
+	};
+	const host = ts.createCompilerHost(options, /*setParentNodes*/ true);
+	const originalReadFile = host.readFile.bind(host);
+	const originalGetSourceFile = host.getSourceFile.bind(host);
+	const hash = ts.sys.createHash ?? defaultHash;
+
+	host.fileExists = n => n in files || n === realLibPath || ts.sys.fileExists(n);
+	host.readFile = (fileName: string) => {
+		const override = fileTextOverrides.get(fileName);
+		if (override !== undefined) return override;
+		if (fileName in files) return files[fileName];
+		if (fileName === realLibPath) return realLibContent;
+		return originalReadFile(fileName);
+	};
+	host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+		const sf = originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+		if (sf && (sf as unknown as { version?: string }).version === undefined) {
+			(sf as unknown as { version: string }).version = hash(sf.text);
+		}
+		return sf;
+	};
+	return host;
+}
+
+function buildProgram(files: Record<string, string>, fileTextOverrides: Map<string, string>, oldProgram?: ts.Program) {
+	const host = makeHost(files, fileTextOverrides);
+	return ts.createProgram({
+		rootNames: Object.keys(files),
+		options: {
+			target: ts.ScriptTarget.Latest,
+			noEmit: true,
+			incremental: true,
+		},
+		host,
+		oldProgram,
+	});
+}
+
+// ── Test 1: BuilderProgram doesn't crash on raw createProgram output ─────
+//
+// This is the regression that motivated the version-stamping override.
+// Without `.version` on each SourceFile, BuilderProgram throws
+// `Debug Failure. Program intended to be used with Builder should have
+// source files with versions set`.
+{
+	const overrides = new Map<string, string>();
+	const program = buildProgram({ '/a.ts': 'const x = 1;' }, overrides);
+
+	let threw: unknown;
+	let builder: ts.SemanticDiagnosticsBuilderProgram | undefined;
+	try {
+		builder = ts.createSemanticDiagnosticsBuilderProgram(program, {
+			createHash: ts.sys.createHash ?? defaultHash,
+		});
+	}
+	catch (err) {
+		threw = err;
+	}
+	check('createSemanticDiagnosticsBuilderProgram does not throw', threw === undefined, threw ? String(threw) : undefined);
+	check('BuilderProgram instance returned', !!builder);
+}
+
+// ── Test 2: every SourceFile in the program has .version stamped ─────────
+{
+	const program = buildProgram({ '/a.ts': 'const x = 1;', '/b.ts': 'const y = 2;' }, new Map());
+	const a = program.getSourceFile('/a.ts')!;
+	const b = program.getSourceFile('/b.ts')!;
+	check('a.version is set', !!(a as unknown as { version?: string }).version);
+	check('b.version is set', !!(b as unknown as { version?: string }).version);
+	check(
+		'distinct contents → distinct versions',
+		(a as unknown as { version: string }).version !== (b as unknown as { version: string }).version,
+	);
+}
+
+// ── Test 3: parent pointers populated (setParentNodes: true) ─────────────
+//
+// compat-eslint's bottom-up materialise walks `ts.Node.parent` chains.
+// `ts.createCompilerHost(options, true)` sets parents at parse time.
+// Without the `true` flag, AST traversal up from a leaf would crash.
+{
+	const program = buildProgram({ '/a.ts': 'const x = 1;' }, new Map());
+	const sf = program.getSourceFile('/a.ts')!;
+	const stmt = sf.statements[0]!; // VariableStatement
+	check('SourceFile root has no parent expectation', sf.parent === undefined);
+	check('top-level statement.parent === SourceFile', stmt.parent === sf);
+	// Drill: VariableStatement → declarationList → declarations[0] → name (Identifier `x`)
+	const list = (stmt as ts.VariableStatement).declarationList;
+	check('declarationList.parent === VariableStatement', list.parent === stmt);
+	const decl = list.declarations[0];
+	check('declaration.parent === declarationList', decl.parent === list);
+	const ident = decl.name;
+	check('identifier.parent === declaration', ident.parent === decl);
+}
+
+// ── Test 4: fileTextOverrides flows through readFile to the program ──────
+{
+	const overrides = new Map<string, string>();
+	overrides.set('/a.ts', 'const overridden = 42;');
+	const program = buildProgram({ '/a.ts': 'const onDisk = 1;' }, overrides);
+	const sf = program.getSourceFile('/a.ts')!;
+	check(
+		'override wins over disk content',
+		sf.text === 'const overridden = 42;',
+		`got: ${sf.text}`,
+	);
+}
+
+// ── Test 5: oldProgram-based rebuild honours overrides ──────────
+//
+// First build: file is on disk. Second build: same file, override flips
+// the content. The rebuilt program must see the new text. (TS's
+// internal reuse strategy across the two programs is an optimisation —
+// what we lock in here is the correctness contract: the override
+// propagates, the unchanged file's text + version are preserved.)
+{
+	type SF = { version?: string };
+	const versionOf = (sf: ts.SourceFile) => (sf as unknown as SF).version;
+	const overrides = new Map<string, string>();
+	const first = buildProgram(
+		{ '/a.ts': 'const x = 1;', '/b.ts': 'const y = 2;' },
+		overrides,
+	);
+	const firstA = first.getSourceFile('/a.ts')!;
+	const firstB = first.getSourceFile('/b.ts')!;
+	check('first build: a.ts has on-disk text', firstA.text === 'const x = 1;');
+
+	overrides.set('/a.ts', 'const x = 999;'); // simulate --fix rewriting a.ts
+	const second = buildProgram(
+		{ '/a.ts': 'const x = 1;', '/b.ts': 'const y = 2;' },
+		overrides,
+		first,
+	);
+	const secondA = second.getSourceFile('/a.ts')!;
+	const secondB = second.getSourceFile('/b.ts')!;
+
+	check('rebuild: a.ts has overridden text', secondA.text === 'const x = 999;');
+	check('rebuild: b.ts text unchanged', secondB.text === 'const y = 2;');
+	// Version stamping is content-addressed → identical text after rebuild
+	// produces identical version. Lets BuilderProgram's reference-graph
+	// diff identify b.ts as unchanged across the rebuild.
+	check(
+		'b.ts version stable across rebuild (content-addressed)',
+		versionOf(secondB) === versionOf(firstB),
+		`first=${versionOf(firstB)}, second=${versionOf(secondB)}`,
+	);
+	check(
+		'a.ts version differs across rebuild (content changed)',
+		versionOf(secondA) !== versionOf(firstA),
+	);
+}
+
+// ── Test 6: BuilderProgram drain works on a Program with overrides ──────
+//
+// End-to-end: the same setup the worker uses for layer-2 affected-file
+// computation. Drain should walk every file, no crashes.
+{
+	const program = buildProgram(
+		{ '/a.ts': 'const x = 1;', '/b.ts': 'const y = 2;' },
+		new Map(),
+	);
+	const builder = ts.createSemanticDiagnosticsBuilderProgram(program, {
+		createHash: ts.sys.createHash ?? defaultHash,
+	});
+	const affected = new Set<string>();
+	const recordAffected = (sf: ts.SourceFile) => {
+		const a = sf as ts.SourceFile | ts.Program;
+		if ('fileName' in a) {
+			affected.add(a.fileName);
+		}
+		else {
+			for (const f of a.getSourceFiles()) affected.add(f.fileName);
+		}
+		return true;
+	};
+	let drained = 0;
+	while (true) {
+		const r = builder.getSemanticDiagnosticsOfNextAffectedFile(undefined, recordAffected);
+		if (!r) break;
+		drained++;
+		if (drained > 100) {
+			failures.push('drain ran away (no termination)');
+			break;
+		}
+	}
+	check('drain found affected user files', affected.has('/a.ts') && affected.has('/b.ts'));
+}
+
+process.stdout.write('\n');
+if (failures.length) {
+	console.error(`\n${failures.length} failure(s):`);
+	for (const f of failures) console.error('  - ' + f);
+	process.exit(1);
+}
+console.log('OK');

--- a/packages/cli/test/program-host.test.ts
+++ b/packages/cli/test/program-host.test.ts
@@ -136,11 +136,11 @@ function buildProgram(files: Record<string, string>, fileTextOverrides: Map<stri
 {
 	const program = buildProgram({ '/a.ts': 'const x = 1;' }, new Map());
 	const sf = program.getSourceFile('/a.ts')!;
-	const stmt = sf.statements[0]!; // VariableStatement
+	const stmt = sf.statements[0] as ts.VariableStatement;
 	check('SourceFile root has no parent expectation', sf.parent === undefined);
 	check('top-level statement.parent === SourceFile', stmt.parent === sf);
 	// Drill: VariableStatement → declarationList → declarations[0] → name (Identifier `x`)
-	const list = (stmt as ts.VariableStatement).declarationList;
+	const list = stmt.declarationList;
 	check('declarationList.parent === VariableStatement', list.parent === stmt);
 	const decl = list.declarations[0];
 	check('declaration.parent === declarationList', decl.parent === list);

--- a/packages/config/lib/plugins/diagnostics.ts
+++ b/packages/config/lib/plugins/diagnostics.ts
@@ -4,9 +4,9 @@ type CheckMode = 'syntactic' | 'semantic' | 'declaration';
 
 export function create(mode: CheckMode | CheckMode[] = 'semantic'): Plugin {
 	const modes = Array.isArray(mode) ? mode : [mode];
-	return ({ languageService }) => ({
+	return ({ program: getProgram }) => ({
 		resolveDiagnostics(file, diagnostics) {
-			const program = languageService.getProgram()!;
+			const program = getProgram();
 			for (const mode of modes) {
 				const diags = mode === 'syntactic'
 					? program.getSyntacticDiagnostics(file)

--- a/packages/config/lib/plugins/ignore.ts
+++ b/packages/config/lib/plugins/ignore.ts
@@ -57,107 +57,77 @@ export function create(
 	const completeReg1 = /^\s*\/\/(\s*)([\S]*)?$/;
 	const completeReg2 = new RegExp(`//\\s*${cmd}(\\S*)?$`);
 
-	return ({ typescript: ts, languageService }) => {
+	return ({ typescript: ts }) => {
 		const reportedRulesOfFile = new Map<string, [string, number][]>();
-		const { getCompletionsAtPosition } = languageService;
 
-		languageService.getCompletionsAtPosition = (fileName, position, ...rest) => {
-			let result = getCompletionsAtPosition(fileName, position, ...rest);
+		return {
+			// IDE-side suggestions: when typing `// @ts-` on a fresh line,
+			// suggest the configured ignore-comment command; when the
+			// command is already typed, suggest rule IDs that fired on the
+			// next line so users can scope the ignore precisely. Only runs
+			// under typescript-plugin (CLI doesn't aggregate completions).
+			resolveCompletions(file, position, entries) {
+				const reportedRules = reportedRulesOfFile.get(file.fileName);
+				const line = file.getLineAndCharacterOfPosition(position).line;
+				const lineStart = file.getPositionOfLineAndCharacter(line, 0);
+				const prefix = file.text.slice(lineStart, position);
+				const matchCmd = prefix.match(completeReg1);
 
-			const sourceFile = languageService.getProgram()?.getSourceFile(fileName);
-			if (!sourceFile) {
-				return result;
-			}
-
-			const reportedRules = reportedRulesOfFile.get(fileName);
-			const line = sourceFile.getLineAndCharacterOfPosition(position).line;
-			const lineStart = sourceFile.getPositionOfLineAndCharacter(line, 0);
-			const prefix = sourceFile.text.slice(lineStart, position);
-			const matchCmd = completeReg1
-				? prefix.match(completeReg1)
-				: undefined;
-
-			if (matchCmd) {
-				const nextLineRules = reportedRules?.filter(([, reportedLine]) => reportedLine === line + 1) ?? [];
-				const item: ts.CompletionEntry = {
-					name: cmdText,
-					insertText: matchCmd[1].length ? cmdText : ` ${cmdText}`,
-					kind: ts.ScriptElementKind.keyword,
-					sortText: 'a',
-					replacementSpan: matchCmd[2]
-						? {
-							start: position - matchCmd[2].length,
-							length: matchCmd[2].length,
-						}
-						: undefined,
-					labelDetails: {
-						description: nextLineRules.length >= 2
-							? `Ignore ${nextLineRules.length} issues in next line`
-							: nextLineRules.length
-							? 'Ignore 1 issue in next line'
+				if (matchCmd) {
+					const nextLineRules = reportedRules?.filter(([, reportedLine]) => reportedLine === line + 1) ?? [];
+					entries.push({
+						name: cmdText,
+						insertText: matchCmd[1].length ? cmdText : ` ${cmdText}`,
+						kind: ts.ScriptElementKind.keyword,
+						sortText: 'a',
+						replacementSpan: matchCmd[2]
+							? {
+								start: position - matchCmd[2].length,
+								length: matchCmd[2].length,
+							}
 							: undefined,
-					},
-				};
-				if (result) {
-					result.entries.push(item);
-				}
-				else {
-					result = {
-						isGlobalCompletion: false,
-						isMemberCompletion: false,
-						isNewIdentifierLocation: false,
-						entries: [item],
-					};
-				}
-			}
-			else if (reportedRules?.length) {
-				const matchRule = completeReg2
-					? prefix.match(completeReg2)
-					: undefined;
-				if (matchRule) {
-					const visited = new Set<string>();
-					for (const [ruleId] of reportedRules) {
-						if (visited.has(ruleId)) {
-							continue;
-						}
-						visited.add(ruleId);
-
-						const reportedLines = reportedRules
-							.filter(([r]) => r === ruleId)
-							.map(([, l]) => l + 1);
-						const item: ts.CompletionEntry = {
-							name: ruleId,
-							kind: ts.ScriptElementKind.keyword,
-							sortText: ruleId,
-							replacementSpan: matchRule[1]
-								? {
-									start: position - matchRule[1].length,
-									length: matchRule[1].length,
-								}
+						labelDetails: {
+							description: nextLineRules.length >= 2
+								? `Ignore ${nextLineRules.length} issues in next line`
+								: nextLineRules.length
+								? 'Ignore 1 issue in next line'
 								: undefined,
-							labelDetails: {
-								description: `Reported in line${reportedLines.length >= 2 ? 's' : ''} ${reportedLines.join(', ')}`,
-							},
-						};
-						if (result) {
-							result.entries.push(item);
-						}
-						else {
-							result = {
-								isGlobalCompletion: false,
-								isMemberCompletion: false,
-								isNewIdentifierLocation: false,
-								entries: [item],
-							};
+						},
+					});
+				}
+				else if (reportedRules?.length) {
+					const matchRule = prefix.match(completeReg2);
+					if (matchRule) {
+						const visited = new Set<string>();
+						for (const [ruleId] of reportedRules) {
+							if (visited.has(ruleId)) {
+								continue;
+							}
+							visited.add(ruleId);
+
+							const reportedLines = reportedRules
+								.filter(([r]) => r === ruleId)
+								.map(([, l]) => l + 1);
+							entries.push({
+								name: ruleId,
+								kind: ts.ScriptElementKind.keyword,
+								sortText: ruleId,
+								replacementSpan: matchRule[1]
+									? {
+										start: position - matchRule[1].length,
+										length: matchRule[1].length,
+									}
+									: undefined,
+								labelDetails: {
+									description: `Reported in line${reportedLines.length >= 2 ? 's' : ''} ${reportedLines.join(', ')}`,
+								},
+							});
 						}
 					}
 				}
-			}
 
-			return result;
-		};
-
-		return {
+				return entries;
+			},
 			resolveDiagnostics(file, results) {
 				if (
 					!reportsUnusedComments

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -434,21 +434,13 @@ export function combineCodeFixes(fileName: string, fixes: ts.CodeFixAction[]) {
 	return finalTextChanges;
 }
 
-export function applyTextChanges(baseSnapshot: ts.IScriptSnapshot, textChanges: ts.TextChange[]): ts.IScriptSnapshot {
-	textChanges = [...textChanges].sort((a, b) => b.span.start - a.span.start);
-	let text = baseSnapshot.getText(0, baseSnapshot.getLength());
-	for (const change of textChanges) {
+export function applyTextChanges(baseText: string, textChanges: ts.TextChange[]): string {
+	// Apply edits back-to-front so each change's offsets remain valid as
+	// earlier ones shift the suffix.
+	const sorted = [...textChanges].sort((a, b) => b.span.start - a.span.start);
+	let text = baseText;
+	for (const change of sorted) {
 		text = text.slice(0, change.span.start) + change.newText + text.slice(change.span.start + change.span.length);
 	}
-	return {
-		getText(start, end) {
-			return text.substring(start, end);
-		},
-		getLength() {
-			return text.length;
-		},
-		getChangeRange() {
-			return undefined;
-		},
-	};
+	return text;
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -72,10 +72,12 @@ export function createLinter(
 			const skipRules = options?.skipRules;
 
 			const rules = getRulesForFile(fileName);
-			const token = ctx.languageServiceHost.getCancellationToken?.();
 			const configs = getConfigsForFile(fileName);
 
-			const program = ctx.languageService.getProgram()!;
+			// Single read at top of `lint()`: rule callbacks all observe
+			// the same Program identity for this file's pass, even if a
+			// caller swaps the underlying program between `lint()` calls.
+			const program = ctx.program();
 			const file = program.getSourceFile(fileName)!;
 			let touchedProgram = false;
 			const rulesContext: RuleContext = {
@@ -93,10 +95,6 @@ export function createLinter(
 			const lintResult = lintResults.get(fileName)!;
 
 			for (const [ruleId, rule] of Object.entries(rules)) {
-				if (token?.isCancellationRequested()) {
-					break;
-				}
-
 				currentRuleId = ruleId;
 
 				if (skipRules?.has(currentRuleId)) {
@@ -324,6 +322,26 @@ export function createLinter(
 					return refactor.getEdits();
 				}
 			}
+		},
+		// IDE-side completion entries. Aggregates `resolveCompletions`
+		// across plugins; CLI never calls this. typescript-plugin merges
+		// the result into the host LanguageService's getCompletionsAtPosition.
+		getCompletions(fileName: string, position: number): ts.CompletionEntry[] {
+			const program = ctx.program();
+			const file = program.getSourceFile(fileName);
+			if (!file) {
+				return [];
+			}
+			const configs = getConfigsForFile(fileName);
+			let entries: ts.CompletionEntry[] = [];
+			for (const { plugins } of configs) {
+				for (const { resolveCompletions } of plugins) {
+					if (resolveCompletions) {
+						entries = resolveCompletions(file, position, entries);
+					}
+				}
+			}
+			return entries;
 		},
 		getRules: getRulesForFile,
 		getConfigs: getConfigsForFile,

--- a/packages/core/test/completions.test.ts
+++ b/packages/core/test/completions.test.ts
@@ -1,0 +1,206 @@
+// Tests for `linter.getCompletions` — the IDE-side aggregator that
+// merges `resolveCompletions` results from configured plugins. Exists
+// because pre-3.2 the `@tsslint/config` ignore plugin reached for the
+// host's `LanguageService.getCompletionsAtPosition` directly via
+// `LinterContext`. That coupling is gone — plugins now expose
+// completions through this hook, and `typescript-plugin` merges the
+// aggregator's output into the host LS's completion result.
+//
+// Run via:
+//   node packages/core/test/completions.test.js
+
+import type { Config, PluginInstance } from '@tsslint/types';
+import * as ts from 'typescript';
+
+const core = require('../index.js') as typeof import('../index.js');
+
+const failures: string[] = [];
+function check(name: string, cond: boolean, detail?: string) {
+	if (cond) {
+		process.stdout.write('.');
+	}
+	else {
+		failures.push(name + (detail ? ' — ' + detail : ''));
+		process.stdout.write('F');
+	}
+}
+
+function makeContext(files: Record<string, string>) {
+	const realLibPath = ts.getDefaultLibFilePath({ target: ts.ScriptTarget.Latest });
+	const realLibContent = ts.sys.readFile(realLibPath) ?? '';
+	const host: ts.LanguageServiceHost = {
+		getCompilationSettings: () => ({
+			target: ts.ScriptTarget.Latest,
+			noEmit: true,
+			lib: [realLibPath.split(/[\\/]/).pop()!],
+		}),
+		getScriptFileNames: () => Object.keys(files),
+		getScriptVersion: () => '1',
+		getScriptSnapshot: n => {
+			if (n in files) return ts.ScriptSnapshot.fromString(files[n]);
+			if (n === realLibPath) return ts.ScriptSnapshot.fromString(realLibContent);
+			return undefined;
+		},
+		getCurrentDirectory: () => '/',
+		getDefaultLibFileName: () => realLibPath,
+		fileExists: n => n in files || n === realLibPath,
+		readFile: n => (n in files ? files[n] : (n === realLibPath ? realLibContent : undefined)),
+	};
+	const languageService = ts.createLanguageService(host);
+	return { typescript: ts, program: () => languageService.getProgram()! };
+}
+
+// ── Test 1: no plugins → empty entries ───────────────────────────────────
+{
+	const ctx = makeContext({ '/a.ts': 'const x = 1;' });
+	const config: Config = { rules: {} };
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	const result = linter.getCompletions('/a.ts', 0);
+	check('no plugins: returns empty array', Array.isArray(result) && result.length === 0);
+}
+
+// ── Test 2: single plugin contributes an entry ────────────────────────────
+{
+	const ctx = makeContext({ '/a.ts': 'const x = 1;' });
+	const plugin: PluginInstance = {
+		resolveCompletions(_file, _position, entries) {
+			entries.push({
+				name: 'my-completion',
+				kind: ts.ScriptElementKind.keyword,
+				sortText: 'a',
+			});
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => plugin],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	const result = linter.getCompletions('/a.ts', 0);
+	check('single plugin: 1 entry returned', result.length === 1);
+	check('single plugin: name is correct', result[0]?.name === 'my-completion');
+}
+
+// ── Test 3: multiple plugins compose; later plugin sees earlier entries ──
+{
+	const ctx = makeContext({ '/a.ts': 'const x = 1;' });
+	let observedByPluginB: number | undefined;
+	const pluginA: PluginInstance = {
+		resolveCompletions(_file, _position, entries) {
+			entries.push({ name: 'a', kind: ts.ScriptElementKind.keyword, sortText: 'a' });
+			return entries;
+		},
+	};
+	const pluginB: PluginInstance = {
+		resolveCompletions(_file, _position, entries) {
+			// B sees A's entry already in the array (proves left-to-right
+			// composition with an aggregating accumulator).
+			observedByPluginB = entries.length;
+			entries.push({ name: 'b', kind: ts.ScriptElementKind.keyword, sortText: 'b' });
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => pluginA, () => pluginB],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	const result = linter.getCompletions('/a.ts', 0);
+	check('two plugins: 2 entries total', result.length === 2);
+	check('plugin B saw plugin A\'s entry first', observedByPluginB === 1);
+	check('order preserved: a before b', result[0]?.name === 'a' && result[1]?.name === 'b');
+}
+
+// ── Test 4: plugin without resolveCompletions doesn't break aggregator ───
+{
+	const ctx = makeContext({ '/a.ts': 'const x = 1;' });
+	const pluginNoCompletions: PluginInstance = {
+		resolveDiagnostics(_file, diagnostics) {
+			return diagnostics;
+		},
+		// no resolveCompletions
+	};
+	const pluginWithCompletions: PluginInstance = {
+		resolveCompletions(_file, _position, entries) {
+			entries.push({ name: 'only', kind: ts.ScriptElementKind.keyword, sortText: 'a' });
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => pluginNoCompletions, () => pluginWithCompletions],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	const result = linter.getCompletions('/a.ts', 0);
+	check('skips plugin without resolveCompletions', result.length === 1);
+	check('still gets entry from contributing plugin', result[0]?.name === 'only');
+}
+
+// ── Test 5: missing file returns empty (program.getSourceFile undefined) ──
+{
+	const ctx = makeContext({ '/a.ts': 'const x = 1;' });
+	const plugin: PluginInstance = {
+		resolveCompletions(_file, _position, entries) {
+			entries.push({ name: 'should-not-appear', kind: ts.ScriptElementKind.keyword, sortText: 'a' });
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => plugin],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	// Asking about a file not in the program — guard short-circuits to [].
+	const result = linter.getCompletions('/does-not-exist.ts', 0);
+	check('missing file: empty result, plugin not invoked', result.length === 0);
+}
+
+// ── Test 6: plugin receives the SourceFile for the requested file ────────
+{
+	const ctx = makeContext({ '/a.ts': 'const hello = 1;' });
+	let observedFileName: string | undefined;
+	let observedText: string | undefined;
+	const plugin: PluginInstance = {
+		resolveCompletions(file, _position, entries) {
+			observedFileName = file.fileName;
+			observedText = file.text;
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => plugin],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	linter.getCompletions('/a.ts', 5);
+	check('plugin sees correct fileName', observedFileName === '/a.ts');
+	check('plugin sees correct text', observedText === 'const hello = 1;');
+}
+
+// ── Test 7: position is passed through to plugin verbatim ────────────────
+{
+	const ctx = makeContext({ '/a.ts': 'const hello = 1;' });
+	let observedPosition: number | undefined;
+	const plugin: PluginInstance = {
+		resolveCompletions(_file, position, entries) {
+			observedPosition = position;
+			return entries;
+		},
+	};
+	const config: Config = {
+		rules: {},
+		plugins: [() => plugin],
+	};
+	const linter = core.createLinter(ctx, '/', config, () => []);
+	linter.getCompletions('/a.ts', 12);
+	check('plugin receives requested position', observedPosition === 12);
+}
+
+process.stdout.write('\n');
+if (failures.length) {
+	console.error(`\n${failures.length} failure(s):`);
+	for (const f of failures) console.error('  - ' + f);
+	process.exit(1);
+}
+console.log('OK');

--- a/packages/core/test/completions.test.ts
+++ b/packages/core/test/completions.test.ts
@@ -108,7 +108,7 @@ function makeContext(files: Record<string, string>) {
 	const linter = core.createLinter(ctx, '/', config, () => []);
 	const result = linter.getCompletions('/a.ts', 0);
 	check('two plugins: 2 entries total', result.length === 2);
-	check('plugin B saw plugin A\'s entry first', observedByPluginB === 1);
+	check("plugin B saw plugin A's entry first", observedByPluginB === 1);
 	check('order preserved: a before b', result[0]?.name === 'a' && result[1]?.name === 'b');
 }
 

--- a/packages/core/test/probe.test.ts
+++ b/packages/core/test/probe.test.ts
@@ -47,7 +47,7 @@ function makeContext(files: Record<string, string>) {
 		readFile: n => (n in files ? files[n] : (n === realLibPath ? realLibContent : undefined)),
 	};
 	const languageService = ts.createLanguageService(host);
-	return { typescript: ts, languageServiceHost: host, languageService };
+	return { typescript: ts, program: () => languageService.getProgram()! };
 }
 
 // ── Test 1: rule that doesn't read program → not classified ──────────────

--- a/packages/core/test/skip-rules.test.ts
+++ b/packages/core/test/skip-rules.test.ts
@@ -42,7 +42,8 @@ function makeContext(files: Record<string, string>) {
 		fileExists: n => n in files || n === realLibPath,
 		readFile: n => (n in files ? files[n] : (n === realLibPath ? realLibContent : undefined)),
 	};
-	return { typescript: ts, languageServiceHost: host, languageService: ts.createLanguageService(host) };
+	const languageService = ts.createLanguageService(host);
+	return { typescript: ts, program: () => languageService.getProgram()! };
 }
 
 // ── Test 1: rule in skipRules doesn't run, no diagnostic in result ───────

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,18 +1,30 @@
 import type {
 	CodeFixAction,
+	CompletionEntry,
 	Diagnostic,
 	DiagnosticWithLocation,
 	FileTextChanges,
-	LanguageService,
-	LanguageServiceHost,
 	Program,
 	SourceFile,
 } from 'typescript';
 
 export interface LinterContext {
 	typescript: typeof import('typescript');
-	languageServiceHost: LanguageServiceHost;
-	languageService: LanguageService;
+	// Program thunk (not a stable instance). Callers that mutate the
+	// project mid-session (e.g. CLI `--fix` rewriting a file) rebuild the
+	// Program and the next `lint()` call sees the new one. Each `lint()`
+	// reads this once at the top, so within a single file's pass the
+	// Program identity stays stable.
+	//
+	// Pre-3.2: this was `{ languageService, languageServiceHost }`.
+	// LinterContext consumed only `getProgram()` and `getCancellationToken()`
+	// from those — the rest of the LS / Host surface was unused, so the
+	// indirection was paying for capabilities (completions, refactors,
+	// navigation) that the linter never touches. Direct Program access
+	// also makes the surface trivially compatible with hosts that don't
+	// run a full LanguageService (raw `ts.createProgram`, tsgo's
+	// `Project.program`, etc.).
+	program: () => Program;
 }
 
 export interface Config {
@@ -30,6 +42,12 @@ export interface PluginInstance {
 	resolveRules?(fileName: string, rules: Record<string, Rule>): Record<string, Rule>;
 	resolveDiagnostics?(file: SourceFile, diagnostics: DiagnosticWithLocation[]): DiagnosticWithLocation[];
 	resolveCodeFixes?(file: SourceFile, diagnostic: Diagnostic, codeFixes: CodeFixAction[]): CodeFixAction[];
+	// IDE-side completion entries. Hosted environments (typescript-plugin)
+	// merge the result into `LanguageService.getCompletionsAtPosition`.
+	// CLI ignores it. Pre-3.2 the ignore plugin reached for `LanguageService`
+	// directly via `LinterContext`; that path is gone, so plugins that want
+	// IDE completions hook in here instead.
+	resolveCompletions?(file: SourceFile, position: number, entries: CompletionEntry[]): CompletionEntry[];
 }
 
 export interface Rules {

--- a/packages/typescript-plugin/index.ts
+++ b/packages/typescript-plugin/index.ts
@@ -40,6 +40,7 @@ function decorateLanguageService(
 		getSemanticDiagnostics,
 		getCodeFixesAtPosition,
 		getCombinedCodeFix,
+		getCompletionsAtPosition,
 		getApplicableRefactors,
 		getEditsForRefactor,
 	} = info.languageService;
@@ -90,6 +91,33 @@ function decorateLanguageService(
 			};
 		}
 		return getCombinedCodeFix(scope, fixId, formatOptions, preferences);
+	};
+	// Merge plugin-supplied completion entries (e.g. ignore-comment
+	// suggestions from `@tsslint/config`'s ignore plugin) into the host's
+	// own completion result. Pre-3.2 plugins reached for
+	// `LanguageService.getCompletionsAtPosition` directly via
+	// `LinterContext`; the cleaner Program-based context takes that path
+	// away, so the IDE side reaches in through `linter.getCompletions`
+	// instead.
+	info.languageService.getCompletionsAtPosition = (fileName, position, ...rest) => {
+		let result = getCompletionsAtPosition(fileName, position, ...rest);
+		if (linter && isProjectFileName(fileName)) {
+			const extra = linter.getCompletions(fileName, position);
+			if (extra.length) {
+				if (result) {
+					result.entries.push(...extra);
+				}
+				else {
+					result = {
+						isGlobalCompletion: false,
+						isMemberCompletion: false,
+						isNewIdentifierLocation: false,
+						entries: extra,
+					};
+				}
+			}
+		}
+		return result;
 	};
 	info.languageService.getApplicableRefactors = (
 		fileName,
@@ -167,8 +195,8 @@ function decorateLanguageService(
 			}
 
 			const projectContext: LinterContext = {
-				...info,
 				typescript: ts,
+				program: () => info.languageService.getProgram()!,
 			};
 
 			try {


### PR DESCRIPTION
## What

Replace `LinterContext = { typescript, languageService, languageServiceHost }` with `{ typescript, program: () => Program }` and drop `ts.createLanguageService` from the CLI worker. Linting now runs end-to-end against `ts.Program` only, with no LanguageService anywhere on the path.

```ts
// before
interface LinterContext {
  typescript: typeof import('typescript');
  languageService: ts.LanguageService;
  languageServiceHost: ts.LanguageServiceHost;
}

// after
interface LinterContext {
  typescript: typeof import('typescript');
  program: () => ts.Program;
}
```

The thunk (vs a stable instance) lets callers swap programs mid-session — `--fix` rewrites a file, flips `programDirty`, the next `lint()` reads a freshly built program. Each `lint()` reads the thunk once at the top so program identity stays stable for that file's pass.

## Why

tsgo (`@typescript/native-preview`) exposes `Snapshot` / `Project` / `Program` / `Checker` — no `LanguageService` equivalent. The pre-3.2 LS-coupled core was the largest blocker for tsgo integration; with the surface shrunk to a Program thunk, tsgo's `Project.program` slots straight in.

This also pays for itself today: `ts.createLanguageService` pulls in completion / refactor / navigation / watcher machinery that the linter never touched.

## CLI worker (the bulk of the diff)

`packages/cli/lib/worker.ts` no longer instantiates a LanguageService. It now:

- Builds a `ts.CompilerHost` directly. Overrides `getSourceFile` for (a) `setParentNodes: true` (compat-eslint walks `Node.parent`), (b) `SourceFile.version` content-hash stamping (BuilderProgram requires it), and (c) Vue / MDX / Astro virtualisation via the active language plugin.
- Hand-rolls the Volar setup (`createLanguage` + `resolveFileLanguageId`) instead of calling `proxyCreateProgram`. The latter applies `decorateProgram` which wraps `getSemanticDiagnostics` to mutate `SourceFile.text` in place — after the AST is parsed — so diagnostic spans land at characters that no longer match the AST. Master got away with this via LS-side `decorateLanguageServiceHost`; we can't.
- Maintains a process-level `sourceFileCache: Map<string, ts.SourceFile>` shared across projects in the same CLI invocation. Pre-3.2 the LS instance survived `setup()` calls and reused lib + shared `node_modules` types across projects; with the LS gone, this restores parity (warm `npm run lint` over 7 tsconfigs: 1.09-1.14s, on par with master).

## `resolveCompletions` plugin hook

The one place that genuinely needed `LanguageService` was `@tsslint/config`'s ignore plugin — it wrapped `getCompletionsAtPosition` to suggest `// @tsslint-ignore`-style comments and rule IDs. Replaced with:

```ts
interface PluginInstance {
  resolveCompletions?(file, position, entries: CompletionEntry[]): CompletionEntry[];
}
```

`Linter.getCompletions(fileName, position)` aggregates across plugins. CLI doesn't call it; `typescript-plugin` wraps the host LS's `getCompletionsAtPosition` and merges in `linter.getCompletions(...)`. Same UX, no LS reach-through inside `@tsslint/config`.

## Public API breakage

- `LinterContext.languageService` removed
- `LinterContext.languageServiceHost` removed
- `LinterContext.program: () => Program` added
- `PluginInstance.resolveCompletions` added (optional)

Affects custom `LinterContext` consumers and any plugin reaching for `ctx.languageService` directly. The path forward is `ctx.program()` for type info, `resolveCompletions` for completion contributions.

## Tests

New:
- `packages/core/test/completions.test.ts` — `resolveCompletions` aggregator (7 cases)
- `packages/cli/test/program-host.test.ts` — version stamping, `setParentNodes`, `fileTextOverrides` flow, `oldProgram` rebuild (6 cases)
- `packages/cli/test/meta-frameworks.test.ts` — spawns the real CLI on `fixtures/meta-frameworks` for `--vue-project` / `--mdx-project` / `--astro-project` / `--vue-vine-project`, asserts `no-console` fires on each framework's script content

Existing tests adjusted for the new context shape. Dify CLI cold lint: bit-identical to master (2961 passed / 1867 errors / 9 messages).
